### PR TITLE
Fix shutdown cost metric

### DIFF
--- a/src/builtin_metrics.jl
+++ b/src/builtin_metrics.jl
@@ -287,7 +287,7 @@ const calc_shutdown_cost = ComponentTimedMetric(;
     name = "ShutdownCost",
     eval_fn = (
         (res::IS.Results, comp::Component; kwargs...) -> let
-            val = read_component_result(res, PSI.StartVariable, comp; kwargs...)
+            val = read_component_result(res, PSI.StopVariable, comp; kwargs...)
             stop_cost = PSY.get_shut_down(PSY.get_operation_cost(comp))
             get_data_vec(val) .*= stop_cost
             return val


### PR DESCRIPTION
`calc_shutdown_cost` currently computes shutdown costs using `PSI.StartVariable`.

This PR switches the metric to use `PSI.StopVariable` instead, so that shutdown costs are accounted for on stop events instead of start events. This also affects the total system cost calculation. 