### PR TITLE
Fix StackOverflowError in metrics.jl by adding type guard and elimina…

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -362,19 +362,10 @@ function _compute_one(metric::ComponentTimedMetric, results::IS.Results,
     agg_fn = get_component_agg_fn(metric)
     meta_agg_fn = get_component_meta_agg_fn(metric)
     components = get_components(selector, results)
-    vals = Vector{DataFrame}()
-    for com in components
-        if com isa ComponentSelector
-            throw(
-                ArgumentError(
-                    "get_components for selector '$(get_name(selector))' returned a " *
-                    "ComponentSelector ($(typeof(com))) instead of a Component. " *
-                    "This would cause infinite recursion if compute is called.",
-                ),
-            )
-        end
-        push!(vals, compute(metric, results, com; kwargs...))
-    end
+    vals = [
+        compute(metric, results, com; kwargs...) for
+        com in components
+    ]
     if length(vals) == 0
         if !isnothing(get_eval_zero(metric))
             result = get_eval_zero(metric)(results; kwargs...)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -369,11 +369,11 @@ function _compute_one(metric::ComponentTimedMetric, results::IS.Results,
                 ArgumentError(
                     "get_components for selector '$(get_name(selector))' returned a " *
                     "ComponentSelector ($(typeof(com))) instead of a Component. " *
-                    "This would cause infinite recursion in compute.",
+                    "This would cause infinite recursion if compute is called.",
                 ),
             )
         end
-        push!(vals, compute(metric, results, com::Component; kwargs...))
+        push!(vals, compute(metric, results, com; kwargs...))
     end
     if length(vals) == 0
         if !isnothing(get_eval_zero(metric))
@@ -698,8 +698,7 @@ function compose_metrics(
         m in metrics
     )
     # Construct the CustomTimedMetric directly instead of recursively calling
-    # compose_metrics, to avoid potential infinite dispatch if the Union method
-    # is re-selected instead of the ComponentSelectorTimedMetric method.
+    # compose_metrics, to avoid potential infinite dispatch issues
     return CustomTimedMetric(; name = name,
         eval_fn = (res::IS.Results, sel::Union{Component, ComponentSelector}; kwargs...) ->
             _common_compose_metrics(

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -362,10 +362,19 @@ function _compute_one(metric::ComponentTimedMetric, results::IS.Results,
     agg_fn = get_component_agg_fn(metric)
     meta_agg_fn = get_component_meta_agg_fn(metric)
     components = get_components(selector, results)
-    vals = [
-        compute(metric, results, com; kwargs...) for
-        com in components
-    ]
+    vals = Vector{DataFrame}()
+    for com in components
+        if com isa ComponentSelector
+            throw(
+                ArgumentError(
+                    "get_components for selector '$(get_name(selector))' returned a " *
+                    "ComponentSelector ($(typeof(com))) instead of a Component. " *
+                    "This would cause infinite recursion in compute.",
+                ),
+            )
+        end
+        push!(vals, compute(metric, results, com::Component; kwargs...))
+    end
     if length(vals) == 0
         if !isnothing(get_eval_zero(metric))
             result = get_eval_zero(metric)(results; kwargs...)
@@ -683,12 +692,25 @@ function compose_metrics(
     name::String,
     reduce_fn,
     metrics::Union{ComponentSelectorTimedMetric, SystemTimedMetric}...)
-    wrapped_metrics = [
+    wrapped_metrics = Tuple(
         (m isa SystemTimedMetric) ? component_selector_metric_from_system_metric(m) : m
         for
         m in metrics
-    ]
-    return compose_metrics(name, reduce_fn, wrapped_metrics...)
+    )
+    # Construct the CustomTimedMetric directly instead of recursively calling
+    # compose_metrics, to avoid potential infinite dispatch if the Union method
+    # is re-selected instead of the ComponentSelectorTimedMetric method.
+    return CustomTimedMetric(; name = name,
+        eval_fn = (res::IS.Results, sel::Union{Component, ComponentSelector}; kwargs...) ->
+            _common_compose_metrics(
+                res,
+                sel,
+                reduce_fn,
+                wrapped_metrics,
+                get_name(sel);
+                kwargs...,
+            ),
+    )
 end
 
 # FUNCTOR INTERFACE TO COMPUTE()


### PR DESCRIPTION

## Problem (Issue #54)

Calling metrics on `ComponentSelector`s (e.g., `calc_active_power(make_selector(ThermalStandard), results)`) sometimes hits a `StackOverflowError` due to two recursive issues in `src/metrics.jl`.

## Potential cause 1
`compute(metric, results, selector::ComponentSelector)`assumes that `com' returned by `get_components` is always a `Component`. If `com` is instead a `ComponentSelector`, Julia dispatches back to the `ComponentSelector` overload — creating an infinite loop:

```
compute(metric, results, selector::ComponentSelector)
  → _compute_one(metric, results, sub)
      → get_components(sub, results) → [items...]
      → compute(metric, results, item)
          → if item isa Component  → OK ✓
          → if item isa ComponentSelector → back to top → StackOverflow error! ✗ (no runtime limit defined) 
```

### Implemented fix: 

Explicit check that each item from `get_components` is a `Component`, not a `ComponentSelector`. If a `ComponentSelector` is encountered, a clear `ArgumentError` is thrown instead of silently recursing to a `StackOverflowError`.

## Potential Cause 2 
The `compose_metrics` overload for `Union{ComponentSelectorTimedMetric, SystemTimedMetric}...` wrapped `SystemTimedMetric`s into `CustomTimedMetric`s and then called `compose_metrics(name, fn, wrapped_metrics...)`, relying on Julia's dispatch to select the more-specific `ComponentSelectorTimedMetric...` overload. This could also lead to potential runtime errors if dispatch instead re-selected the `Union` method.

### Implemented fix

Replaced the recursive `compose_metrics(name, fn, wrapped_metrics...)` call with a direct `CustomTimedMetric` construction — exactly what the `ComponentSelectorTimedMetric...` overload would have produced — eliminating the dispatch dependency entirely:

## Testing

All **790** existing tests pass with no changes required.