### PR TITLE
fix: map all HydroGen subtypes to Hydropower in generator_mapping.yaml

### DIFF
--- a/deps/generator_mapping.yaml
+++ b/deps/generator_mapping.yaml
@@ -21,6 +21,9 @@ NG-CC:
 NG-Steam:
   - {gentype: Any, primemover: ST, fuel: NATURAL_GAS}
 Hydropower:
+  # Catch all HydroGen subtypes (e.g., HydroPumpTurbine with primemover=PS) before
+  # they fall through to the generic Storage `{Any, PS, null}` rule above.
+  - {gentype: HydroGen, primemover: null, fuel: null}
   - {gentype: Any, primemover: HY, fuel: null}
 Coal:
   - {gentype: Any, primemover: null, fuel: COAL}

--- a/deps/generator_mapping.yaml
+++ b/deps/generator_mapping.yaml
@@ -21,6 +21,7 @@ NG-CC:
 NG-Steam:
   - {gentype: Any, primemover: ST, fuel: NATURAL_GAS}
 Hydropower:
+  - {gentype: HydroGen, primemover: null, fuel: null}
   - {gentype: Any, primemover: HY, fuel: null}
 Coal:
   - {gentype: Any, primemover: null, fuel: COAL}

--- a/test/test_result_sorting.jl
+++ b/test/test_result_sorting.jl
@@ -141,3 +141,15 @@ end
     sys = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
     @test length(PA.get_load_data(sys; aggregation = ACBus).data) == 3
 end
+
+@testset "Test HydroGen subtypes map to Hydropower" begin
+    mapping = PA.get_generator_mapping()
+    # HydroPumpTurbine advertises primemover=PS; without the HydroGen rule it
+    # would fall through to the generic `{Any, PS, null}` Storage rule.
+    @test PA.get_generator_category(
+        PSY.HydroPumpTurbine, nothing, PSY.PrimeMovers.PS, nothing, mapping,
+    ) == "Hydropower"
+    @test PA.get_generator_category(
+        PSY.HydroTurbine, nothing, PSY.PrimeMovers.HY, nothing, mapping,
+    ) == "Hydropower"
+end


### PR DESCRIPTION
PowerSystems v5 added two new hydro types under `HydroGen`: `HydroTurbine` and `HydroPumpTurbine`. The pump-turbine one has a different prime mover code (`PS` for pumped storage) instead of the usual hydro code (`HY`).
 
The way the code figures out what category a generator belongs to is by going up the type tree until it finds a match in the mapping file. Before this fix, there was no entry for any hydro type, so `HydroPumpTurbine` kept going up until it hit a generic fallback that mapped `PS` to **Storage** — which is obviously wrong. This made stack plots show bad data or break when the system had pump-turbines.
 
### The Fix
 
I added one entry to the Hydropower section of `deps/generator_mapping.yaml`, tied to the `HydroGen` parent type with no prime mover restriction.
 
Since `HydroGen` sits higher in the type tree than the generic fallback, this entry gets matched first. That means all hydro subtypes — current and future — should be correctly labeled as **Hydropower** no matter what prime mover code they use.
 
Closes NREL-Sienna/PowerGraphics.jl#132

Tests pass and I did some manual verification but can you double check this fixes your issue @jarry7 ? 