### PR TITLE
Pb/combined fixes 60, 64, 65, 66

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
 Community driven development of this package is encouraged. To maintain code quality standards, please adhere to the following guidlines when contributing:
- - To get started, <a href="https://www.clahub.com/agreements/nrel-sienna/PowerAnalytics.jl">sign the Contributor License Agreement</a>.
+ - To get started, <a href="https://www.clahub.com/agreements/Sienna-Platform/PowerAnalytics.jl">sign the Contributor License Agreement</a>.
  - Please do your best to adhere to our [coding style guide](https://github.com/nrel/powersystems.jl/docs/src/style.md).
  - To submit code contributions, [fork](https://help.github.com/articles/fork-a-repo/) the repository, commit your changes, and [submit a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PowerAnalytics.jl
 
-[![main - CI](https://github.com/NREL-Sienna/PowerAnalytics.jl/actions/workflows/main-tests.yml/badge.svg)](https://github.com/NREL-Sienna/PowerAnalytics.jl/actions/workflows/main-tests.yml)
-[![codecov](https://codecov.io/gh/NREL-Sienna/PowerAnalytics.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/NREL-Sienna/PowerAnalytics.jl)
-[![Documentation Build](https://github.com/NREL-Sienna/PowerAnalytics.jl/workflows/Documentation/badge.svg?)](https://nrel-sienna.github.io/PowerAnalytics.jl/stable)
-[<img src="https://img.shields.io/badge/slack-@Sienna/PG-sienna.svg?logo=slack">](https://join.slack.com/t/nrel-sienna/shared_invite/zt-glam9vdu-o8A9TwZTZqqNTKHa7q3BpQ)
+[![main - CI](https://github.com/Sienna-Platform/PowerAnalytics.jl/actions/workflows/main-tests.yml/badge.svg)](https://github.com/Sienna-Platform/PowerAnalytics.jl/actions/workflows/main-tests.yml)
+[![codecov](https://codecov.io/gh/Sienna-Platform/PowerAnalytics.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/Sienna-Platform/PowerAnalytics.jl)
+[![Documentation Build](https://github.com/Sienna-Platform/PowerAnalytics.jl/workflows/Documentation/badge.svg?)](https://sienna-platform.github.io/PowerAnalytics.jl/stable)
+[<img src="https://img.shields.io/badge/slack-@Sienna/PG-sienna.svg?logo=slack">](https://join.slack.com/t/core-sienna/shared_invite/zt-glam9vdu-o8A9TwZTZqqNTKHa7q3BpQ)
 [![PowerAnalytics Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/PowerAnalytics)](https://pkgs.genieframework.com?packages=PowerAnalytics)
 
-PowerAnalytics.jl is a Julia package that contains analytic routines for power system simulation results in the Sienna ecosystem, specifically from [PowerSimulations.jl](https://github.com/NREL-Sienna/PowerSimulations.jl).
+PowerAnalytics.jl is a Julia package that contains analytic routines for power system simulation results in the Sienna ecosystem, specifically from [PowerSimulations.jl](https://github.com/Sienna-Platform/PowerSimulations.jl).
 
 ## Installation
 
@@ -28,9 +28,9 @@ renewable_generation = calc_active_power(make_selector(RenewableGen), res)
 
 ## Development
 
-Contributions to the development and enhancement of PowerAnalytics is welcome. Please see [CONTRIBUTING.md](https://github.com/NREL-Sienna/PowerAnalytics.jl/blob/main/CONTRIBUTING.md) for code contribution guidelines.
+Contributions to the development and enhancement of PowerAnalytics is welcome. Please see [CONTRIBUTING.md](https://github.com/Sienna-Platform/PowerAnalytics.jl/blob/main/CONTRIBUTING.md) for code contribution guidelines.
 
 ## License
 
-PowerAnalytics is released under a BSD [license](https://github.com/nrel-sienna/PowerAnalytics.jl/blob/main/LICENSE). PowerAnalytics has been developed as part of the Scalable Integrated Infrastructure Planning (SIIP)
+PowerAnalytics is released under a BSD [license](https://github.com/Sienna-Platform/PowerAnalytics.jl/blob/main/LICENSE). PowerAnalytics has been developed as part of the Scalable Integrated Infrastructure Planning (SIIP)
 initiative at the U.S. Department of Energy's National Laboratory of the Rockies ([NLR](https://www.nlr.gov/), formerly NREL)

--- a/deps/generator_mapping.yaml
+++ b/deps/generator_mapping.yaml
@@ -21,6 +21,9 @@ NG-CC:
 NG-Steam:
   - {gentype: Any, primemover: ST, fuel: NATURAL_GAS}
 Hydropower:
+  # Catch all HydroGen subtypes (e.g., HydroPumpTurbine with primemover=PS) before
+  # they fall through to the generic Storage `{Any, PS, null}` rule above.
+  - {gentype: HydroGen, primemover: null, fuel: null}
   - {gentype: Any, primemover: HY, fuel: null}
 Coal:
   - {gentype: Any, primemover: null, fuel: COAL}

--- a/deps/generator_mapping.yaml
+++ b/deps/generator_mapping.yaml
@@ -16,8 +16,10 @@ Storage:
   - {gentype: Any, primemover: PS, fuel: null}
 NG-CT:
   - {gentype: Any, primemover: CT, fuel: NATURAL_GAS}
+  - {gentype: Any, primemover: GT, fuel: NATURAL_GAS}
 NG-CC:
   - {gentype: Any, primemover: CC, fuel: NATURAL_GAS}
+  - {gentype: Any, primemover: CA, fuel: NATURAL_GAS}
 NG-Steam:
   - {gentype: Any, primemover: ST, fuel: NATURAL_GAS}
 Hydropower:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,17 +6,17 @@ using Dates
 using Literate
 
 # UPDATE FOR CURRENT MODULE NAME HERE
-const _DOCS_BASE_URL = "https://nrel-sienna.github.io/PowerAnalytics.jl/stable"
+const _DOCS_BASE_URL = "https://sienna-platform.github.io/PowerAnalytics.jl/stable"
 
 ENV["GKSwstype"] = "100"  # Prevent GR from opening gksqt GUI
 
 links = InterLinks(
     "Julia" => "https://docs.julialang.org/en/v1/",
-    "InfrastructureSystems" => "https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/",
-    "PowerSystems" => "https://nrel-sienna.github.io/PowerSystems.jl/stable/",
-    "PowerSimulations" => "https://nrel-sienna.github.io/PowerSimulations.jl/stable/",
-    "StorageSystemsSimulations" => "https://nrel-sienna.github.io/StorageSystemsSimulations.jl/stable/",
-    "HydroPowerSimulations" => "https://nrel-sienna.github.io/HydroPowerSimulations.jl/dev/",
+    "InfrastructureSystems" => "https://sienna-platform.github.io/InfrastructureSystems.jl/stable/",
+    "PowerSystems" => "https://sienna-platform.github.io/PowerSystems.jl/stable/",
+    "PowerSimulations" => "https://sienna-platform.github.io/PowerSimulations.jl/stable/",
+    "StorageSystemsSimulations" => "https://sienna-platform.github.io/StorageSystemsSimulations.jl/stable/",
+    "HydroPowerSimulations" => "https://sienna-platform.github.io/HydroPowerSimulations.jl/dev/",
 )
 
 include(joinpath(@__DIR__, "make_tutorials.jl"))
@@ -55,7 +55,7 @@ makedocs(
 
 
 deploydocs(
-    repo= "github.com/NREL-Sienna/PowerAnalytics.jl",
+    repo= "github.com/Sienna-Platform/PowerAnalytics.jl",
     target="build",
     branch="gh-pages",
     devbranch="main",

--- a/docs/src/PowerAnalytics/3.0_getting_started.jl
+++ b/docs/src/PowerAnalytics/3.0_getting_started.jl
@@ -1,6 +1,6 @@
 # # Getting Started with PowerAnalytics
 
-# Start by creating a results object using [PowerSimulations](http://github.com/nrel-sienna/PowerSimulations.jl.git)
+# Start by creating a results object using [PowerSimulations](http://github.com/Sienna-Platform/PowerSimulations.jl.git)
 
 # Set up PowerAnalytics:
 # ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-PowerAnalytics.jl is a Julia package designed to support power system simulation results analysis. It relies on results generated from [`PowerSimulations.jl`](https://nrel-sienna.github.io/PowerSimulations.jl/stable/) and data structures defined in [`PowerSystems.jl`](https://nrel-sienna.github.io/PowerSystems.jl/stable/). PowerAnalytics also provides the data collection, aggregation, and subsetting for [`PowerGraphics.jl`](https://nrel-sienna.github.io/PowerGraphics.jl/stable/).
+PowerAnalytics.jl is a Julia package designed to support power system simulation results analysis. It relies on results generated from [`PowerSimulations.jl`](https://sienna-platform.github.io/PowerSimulations.jl/stable/) and data structures defined in [`PowerSystems.jl`](https://sienna-platform.github.io/PowerSystems.jl/stable/). PowerAnalytics also provides the data collection, aggregation, and subsetting for [`PowerGraphics.jl`](https://sienna-platform.github.io/PowerGraphics.jl/stable/).
 
-The tutorial, how-to, and explanation sections of the documentation are still under construction; the most informative section is the [public API reference](reference/public.md). PowerAnalytics depends heavily on the `ComponentSelector` feature of PowerSystems.jl, documented [here](https://nrel-sienna.github.io/PowerSystems.jl/stable/api/public/#InfrastructureSystems.ComponentSelector).
+The tutorial, how-to, and explanation sections of the documentation are still under construction; the most informative section is the [public API reference](reference/public.md). PowerAnalytics depends heavily on the `ComponentSelector` feature of PowerSystems.jl, documented [here](https://sienna-platform.github.io/PowerSystems.jl/stable/api/public/#InfrastructureSystems.ComponentSelector).
 
 ## Installation
 
@@ -25,15 +25,15 @@ The latest stable release of PowerAnalytics can be installed using the Julia pac
 ## About Sienna
 
 `PowerAnalytics.jl` is part of the National Laboratory of the Rockies'
-[Sienna ecosystem](https://nrel-sienna.github.io/Sienna/), an open source framework for
+[Sienna ecosystem](https://sienna-platform.github.io/Sienna/), an open source framework for
 power system modeling, simulation, and optimization. The Sienna ecosystem can be
-[found on GitHub](https://github.com/NREL-Sienna/Sienna). It contains three applications:
+[found on GitHub](https://github.com/Sienna-Platform/Sienna). It contains three applications:
 
-  - [Sienna\Data](https://nrel-sienna.github.io/Sienna/pages/applications/sienna_data.html) enables
+  - [Sienna\Data](https://sienna-platform.github.io/Sienna/pages/applications/sienna_data.html) enables
     efficient data input, analysis, and transformation
-  - [Sienna\Ops](https://nrel-sienna.github.io/Sienna/pages/applications/sienna_ops.html) enables
+  - [Sienna\Ops](https://sienna-platform.github.io/Sienna/pages/applications/sienna_ops.html) enables
     enables system scheduling simulations by formulating and solving optimization problems
-  - [Sienna\Dyn](https://nrel-sienna.github.io/Sienna/pages/applications/sienna_dyn.html) enables
+  - [Sienna\Dyn](https://sienna-platform.github.io/Sienna/pages/applications/sienna_dyn.html) enables
     system transient analysis including small signal stability and full system dynamic
     simulations
 

--- a/docs/src/reference/developer_guidelines.md
+++ b/docs/src/reference/developer_guidelines.md
@@ -1,12 +1,12 @@
 # Developer Guidelines
 
 In order to contribute to `PowerAnalytics.jl` repository please read the following sections of
-[`InfrastructureSystems.jl`](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/) and [`SiennaTemplate.jl`](https://github.com/NREL-Sienna/SiennaTemplate.jl)
+[`InfrastructureSystems.jl`](https://sienna-platform.github.io/InfrastructureSystems.jl/stable/) and [`SiennaTemplate.jl`](https://github.com/Sienna-Platform/SiennaTemplate.jl)
 documentation in detail:
 
- 1. [Style Guide](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/style/)
- 2. [Documentation Best Practices](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/docs_best_practices/explanation/)
- 3. [Contributing Guidelines](https://github.com/NREL-Sienna/SiennaTemplate.jl/blob/main/CONTRIBUTING.md)
+ 1. [Style Guide](https://sienna-platform.github.io/InfrastructureSystems.jl/stable/style/)
+ 2. [Documentation Best Practices](https://sienna-platform.github.io/InfrastructureSystems.jl/stable/docs_best_practices/explanation/)
+ 3. [Contributing Guidelines](https://github.com/Sienna-Platform/SiennaTemplate.jl/blob/main/CONTRIBUTING.md)
 
 Pull requests are always welcome to fix bugs or add additional modeling capabilities.
 

--- a/docs/src/reference/public.md
+++ b/docs/src/reference/public.md
@@ -4,7 +4,7 @@
 
 PowerAnalytics depends heavily on the `ComponentSelector` feature of PowerSystems.jl.
 `ComponentSelector` documentation can be found
-[here](https://nrel-sienna.github.io/PowerSystems.jl/stable/api/public/#InfrastructureSystems.ComponentSelector).
+[here](https://sienna-platform.github.io/PowerSystems.jl/stable/api/public/#InfrastructureSystems.ComponentSelector).
 PowerAnalytics provides some [built-in selectors](@ref Built-in-Selectors), but much of the
 power of PowerAnalytics comes from the ability to operate on custom `ComponentSelector`s.
 
@@ -140,7 +140,7 @@ Private = false
 
 ## Old PowerAnalytics
 
-This interface predates the `1.0` version and will [eventually](https://github.com/NREL-Sienna/PowerAnalytics.jl/issues/28) be deprecated.
+This interface predates the `1.0` version and will [eventually](https://github.com/Sienna-Platform/PowerAnalytics.jl/issues/28) be deprecated.
 
 ```@autodocs
 Modules = [PowerAnalytics]

--- a/docs/src/tutorials/PA_workflow_tutorial.jl
+++ b/docs/src/tutorials/PA_workflow_tutorial.jl
@@ -27,7 +27,7 @@
 #
 #   - **Scenario 2**: simulation using the RTS-GMLC test system with increased energy and power capacity of the storage device
 #
-# The simulations were performed using the [PowerSystems.jl](https://nrel-sienna.github.io/PowerSystems.jl/stable/) and [PowerSimulations.jl](https://nrel-sienna.github.io/PowerSimulations.jl/stable/) packages of Sienna. The [`CopperPlatePowerModel`](@extref) formulation was considered for the [`NetworkModel`](@extref PowerSimulations.NetworkModel), while the formulations chosen for each of the component types we want to include in the simulation are presented in the table below:
+# The simulations were performed using the [PowerSystems.jl](https://sienna-platform.github.io/PowerSystems.jl/stable/) and [PowerSimulations.jl](https://sienna-platform.github.io/PowerSimulations.jl/stable/) packages of Sienna. The [`CopperPlatePowerModel`](@extref) formulation was considered for the [`NetworkModel`](@extref PowerSimulations.NetworkModel), while the formulations chosen for each of the component types we want to include in the simulation are presented in the table below:
 #
 # | Component Type                                      | Formulation                                                                                    |
 # |:--------------------------------------------------- |:---------------------------------------------------------------------------------------------- |
@@ -43,11 +43,11 @@
 #
 # !!! info
 #
-#     More information regarding the different formulations can be found in the [`PowerSimulations.jl` Formulation Library](https://nrel-sienna.github.io/PowerSimulations.jl/stable/formulation_library/Introduction/).
+#     More information regarding the different formulations can be found in the [`PowerSimulations.jl` Formulation Library](https://sienna-platform.github.io/PowerSimulations.jl/stable/formulation_library/Introduction/).
 #
 # We document the above here for completeness, since those will directly define the structure of the optimization problem and consequently its auxiliary variables, expressions, parameters and variables for which realized result values are available.
 #
-# The script that was used to configure and execute the simulation scenarios referenced above can be found [here](https://github.com/NREL-Sienna/PowerAnalytics.jl/tree/main/docs/src/tutorials/_run_scenarios_RTS_Tutorial.jl).
+# The script that was used to configure and execute the simulation scenarios referenced above can be found [here](https://github.com/Sienna-Platform/PowerAnalytics.jl/tree/main/docs/src/tutorials/_run_scenarios_RTS_Tutorial.jl).
 #
 # ## Loading Simulation Scenario Results
 #
@@ -103,7 +103,7 @@ show(df; allcols = true)
 #
 # !!! info
 #
-#     For a complete list of the `PowerAnalytics.jl` built-in metrics, please refer to: [PowerAnalytics Built-In Metrics](https://nrel-sienna.github.io/PowerAnalytics.jl/stable/reference/public/#Built-in-Metrics).
+#     For a complete list of the `PowerAnalytics.jl` built-in metrics, please refer to: [PowerAnalytics Built-In Metrics](https://sienna-platform.github.io/PowerAnalytics.jl/stable/reference/public/#Built-in-Metrics).
 #
 # ### Obtain the thermal generation time series grouped by prime_mover
 #

--- a/src/fuel_results.jl
+++ b/src/fuel_results.jl
@@ -93,7 +93,9 @@ function make_fuel_dictionary(
     kwargs...,
 )
     filter_func2 = x -> PSY.get_available(x) && filter_func(x)
-    generators = PSY.get_components(filter_func2, PSY.StaticInjection, sys)
+    # Fuel-bearing injection types only; excludes Source and other non-fuel StaticInjection subtypes
+    types = Union{PSY.StaticLoad, PSY.Generator, PSY.Storage}
+    generators = PSY.get_components(filter_func2, types, sys)
     gen_categories = Dict()
     for category in unique(values(mapping))
         gen_categories["$category"] = []

--- a/src/get_data.jl
+++ b/src/get_data.jl
@@ -1,13 +1,13 @@
 
 # the fundamental struct for plotting
 struct PowerData
-    data::Dict{Symbol, DataFrames.DataFrame}
-    time::Union{StepRange{Dates.DateTime}, Vector{Dates.DateTime}}
+    data::Dict{Symbol,DataFrames.DataFrame}
+    time::Union{StepRange{Dates.DateTime},Vector{Dates.DateTime}}
 end
 
 function PowerData(
-    data::Dict{PSI.OptimizationContainerKey, DataFrames.DataFrame},
-    time::Union{StepRange{Dates.DateTime}, Vector{Dates.DateTime}},
+    data::Dict{PSI.OptimizationContainerKey,DataFrames.DataFrame},
+    time::Union{StepRange{Dates.DateTime},Vector{Dates.DateTime}},
 )
     d = Dict(zip(Symbol.(PSI.encode_keys_as_strings(keys(data))), values(data)))
 
@@ -16,8 +16,8 @@ function PowerData(
 end
 
 function PowerData(
-    data::Dict{String, DataFrames.DataFrame},
-    time::Union{StepRange{Dates.DateTime}, Vector{Dates.DateTime}},
+    data::Dict{String,DataFrames.DataFrame},
+    time::Union{StepRange{Dates.DateTime},Vector{Dates.DateTime}},
 )
     d = Dict(zip(Symbol.(keys(data))), values(data))
 
@@ -25,7 +25,7 @@ function PowerData(
     return PowerData(d, time)
 end
 
-function PowerData(data::Dict{String, DataFrames.DataFrame})
+function PowerData(data::Dict{String,DataFrames.DataFrame})
     d = Dict(zip(Symbol.(keys(data)), no_datetime.(values(data))))
     return PowerData(d, first(values(data)).DateTime)
 end
@@ -50,7 +50,7 @@ end
 function get_generation_variable_keys(
     results::IS.Results;
     variable_keys::Vector{T} = PSI.list_variable_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     # TODO: add slacks
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in variable_keys
@@ -68,7 +68,7 @@ end
 function get_storage_variable_keys(
     results::IS.Results;
     variable_keys::Vector{T} = PSI.list_variable_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in variable_keys
         if PSI.get_component_type(k) <: PSY.Storage &&
@@ -82,7 +82,7 @@ end
 function get_generation_parameter_keys(
     results::IS.Results;
     parameter_keys::Vector{T} = PSI.list_parameter_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in parameter_keys
         if PSI.get_component_type(k) <: PSY.Generator &&
@@ -96,7 +96,7 @@ end
 function get_generation_aux_variable_keys(
     results::IS.Results;
     aux_variable_keys::Vector{T} = PSI.list_aux_variable_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     # TODO: add slacks
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in aux_variable_keys
@@ -112,7 +112,7 @@ end
 function get_load_variable_keys(
     results::IS.Results;
     variable_keys::Vector{T} = PSI.list_variable_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in variable_keys
         if PSI.get_component_type(k) <: PSY.ElectricLoad &&
@@ -126,7 +126,7 @@ end
 function get_load_parameter_keys(
     results::IS.Results;
     parameter_keys::Vector{T} = PSI.list_parameter_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in parameter_keys
         if PSI.get_component_type(k) <: PSY.ElectricLoad &&
@@ -142,7 +142,7 @@ end
 function get_service_variable_keys(
     results::IS.Results;
     variable_keys::Vector{T} = PSI.list_variable_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in variable_keys
         if PSI.get_component_type(k) <: PSY.Service &&
@@ -156,7 +156,7 @@ end
 function get_service_parameter_names(
     results::IS.Results;
     parameter_keys::Vector{T} = PSI.list_parameter_keys(results),
-) where {T <: PSI.OptimizationContainerKey}
+) where {T<:PSI.OptimizationContainerKey}
     filter_keys = Vector{PSI.OptimizationContainerKey}()
     for k in parameter_keys
         if PSI.get_component_type(k) <: PSY.ElectricLoad &&
@@ -171,9 +171,9 @@ end
 no_datetime(df::DataFrames.DataFrame) = df[:, propertynames(df) .!== :DateTime]
 
 function add_fixed_parameters!(
-    variables::Dict{V, DataFrames.DataFrame},
-    parameters::Dict{P, DataFrames.DataFrame},
-) where {V <: PSI.OptimizationContainerKey, P <: PSI.OptimizationContainerKey}
+    variables::Dict{V,DataFrames.DataFrame},
+    parameters::Dict{P,DataFrames.DataFrame},
+) where {V<:PSI.OptimizationContainerKey,P<:PSI.OptimizationContainerKey}
     # fixed output should be added to plots when there exists a parameter of the form
     # :P__max_active_power__* but there is no corresponding :P__* variable
     for (param_key, param) in parameters
@@ -189,9 +189,9 @@ function add_fixed_parameters!(
 end
 
 function add_aux_variables!(
-    variables::Dict{V, DataFrames.DataFrame},
-    aux_variables::Dict{A, DataFrames.DataFrame},
-) where {V <: PSI.OptimizationContainerKey, A <: PSI.OptimizationContainerKey}
+    variables::Dict{V,DataFrames.DataFrame},
+    aux_variables::Dict{A,DataFrames.DataFrame},
+) where {V<:PSI.OptimizationContainerKey,A<:PSI.OptimizationContainerKey}
     # fixed output should be added to plots when there exists a parameter of the form
     # :P__max_active_power__* but there is no corresponding :P__* variable
     for (param_key, param) in aux_variables
@@ -223,7 +223,7 @@ function _curtailment_parameters(
     curtailment_parameters = Vector{
         NamedTuple{
             (:parameter, :variable),
-            Tuple{PSI.OptimizationContainerKey, PSI.OptimizationContainerKey},
+            Tuple{PSI.OptimizationContainerKey,PSI.OptimizationContainerKey},
         },
     }()
     for pk in curtailable_parameters
@@ -242,7 +242,7 @@ function _filter_curtailment!(
     curtailment_parameters::Vector{
         NamedTuple{
             (:parameter, :variable),
-            Tuple{PSI.OptimizationContainerKey, PSI.OptimizationContainerKey},
+            Tuple{PSI.OptimizationContainerKey,PSI.OptimizationContainerKey},
         },
     },
 )
@@ -265,24 +265,23 @@ function _filter_curtailment!(
 end
 
 function filter_results!(
-    results_dict::Dict{PSI.OptimizationContainerKey, DataFrames.DataFrame},
+    results_dict::Dict{PSI.OptimizationContainerKey,DataFrames.DataFrame},
     filter_func::Function,
     results::R,
-) where {R <: IS.Results}
+) where {R<:IS.Results}
     for (k, v) in results_dict
         component_type = PSI.get_component_type(k)#getfield(PSY, Symbol(last(split(String(k), "__"))))
-        component_names =
-            PSY.get_name.(
-                PSY.get_components(filter_func, component_type, PSI.get_system(results)),
-            )
+        component_names = PSY.get_name.(
+            PSY.get_components(filter_func, component_type, PSI.get_system(results)),
+        )
         DataFrames.select!(v, vcat(["DateTime"], component_names))
     end
 end
 function filter_results!(
-    results_dict::Dict{PSI.OptimizationContainerKey, DataFrames.DataFrame},
+    results_dict::Dict{PSI.OptimizationContainerKey,DataFrames.DataFrame},
     filter_func::Nothing,
     results::R,
-) where {R <: IS.Results} end
+) where {R<:IS.Results} end
 
 function get_generation_data(
     results::R;
@@ -292,9 +291,9 @@ function get_generation_data(
     #     Type{PSY.System},
     #     Type{<:PSY.AggregationTopology},
     # } = PSY.StaticInjection,
-    filter_func::Union{Function, Nothing} = nothing,
+    filter_func::Union{Function,Nothing} = nothing,
     kwargs...,
-) where {R <: IS.Results}
+) where {R<:IS.Results}
     initial_time = get(kwargs, :initial_time, get(kwargs, :start_time, nothing))
     len = get(kwargs, :horizon, get(kwargs, :len, nothing))
     variable_keys = get(kwargs, :variable_keys, PSI.list_variable_keys(results))
@@ -361,9 +360,9 @@ end
 
 function get_load_data(
     results::R;
-    filter_func::Union{Function, Nothing} = nothing,
+    filter_func::Union{Function,Nothing} = nothing,
     kwargs...,
-) where {R <: IS.Results}
+) where {R<:IS.Results}
     initial_time = get(kwargs, :initial_time, get(kwargs, :start_time, nothing))
     len = get(kwargs, :horizon, get(kwargs, :len, nothing))
     variable_keys = get(kwargs, :variable_keys, PSI.list_variable_keys(results))
@@ -414,7 +413,7 @@ function _get_loads(system::PSY.System, bus::PSY.ACBus)
         PSY.get_bus(load) == bus
     ]
 end
-function _get_loads(system::PSY.System, agg::T) where {T <: PSY.AggregationTopology}
+function _get_loads(system::PSY.System, agg::T) where {T<:PSY.AggregationTopology}
     return PSY.get_components_in_aggregation_topology(PSY.StaticLoad, system, agg)
 end
 function _get_loads(system::PSY.System, load::PSY.StaticLoad)
@@ -444,7 +443,7 @@ function get_load_data(
     end
     horizon = get(kwargs, :horizon, PSY.get_forecast_horizon(system))
     initial_time = get(kwargs, :initial_time, PSY.get_forecast_initial_timestamp(system))
-    parameters = Dict{Symbol, DataFrames.DataFrame}()
+    parameters = Dict{Symbol,DataFrames.DataFrame}()
     PSY.set_units_base_system!(system, "SYSTEM_BASE")
     resolution = nothing
     len = nothing
@@ -458,7 +457,7 @@ function get_load_data(
             keys = filter(
                 key ->
                     PSY.get_time_series_type(key) <: PSY.AbstractDeterministic &&
-                        PSY.get_name(key) == "max_active_power",
+                    PSY.get_name(key) == "max_active_power",
                 PSY.get_time_series_keys(load),
             )
             @assert length(keys) == 1
@@ -485,13 +484,7 @@ function get_load_data(
     time_range = if isnothing(len)
         Dates.DateTime[]
     else
-        collect(
-            range(
-                initial_time;
-                step = resolution,
-                length = len,
-            ),
-        )
+        collect(range(initial_time; step = resolution, length = len))
     end
 
     return PowerData(parameters, time_range)
@@ -499,9 +492,9 @@ end
 
 function get_service_data(
     results::R;
-    filter_func::Union{Function, Nothing} = nothing,
+    filter_func::Union{Function,Nothing} = nothing,
     kwargs...,
-) where {R <: IS.Results}
+) where {R<:IS.Results}
     initial_time = get(kwargs, :initial_time, get(kwargs, :start_time, nothing))
     len = get(kwargs, :horizon, get(kwargs, :len, nothing))
     variable_keys = get(kwargs, :variable_keys, PSI.list_variable_keys(results))
@@ -536,9 +529,9 @@ PG.combine_categories(gen_uc.data)
 
 """
 function combine_categories(
-    data::Union{Dict{Symbol, DataFrames.DataFrame}, Dict{String, DataFrames.DataFrame}};
-    names::Union{Vector{String}, Vector{Symbol}, Nothing} = nothing,
-    aggregate::Union{Function, Nothing} = nothing,
+    data::Union{Dict{Symbol,DataFrames.DataFrame},Dict{String,DataFrames.DataFrame}};
+    names::Union{Vector{String},Vector{Symbol},Nothing} = nothing,
+    aggregate::Union{Function,Nothing} = nothing,
 )
     aggregate = isnothing(aggregate) ? x -> sum(x; dims = 2) : aggregate
     names = isnothing(names) ? keys(data) : names
@@ -569,12 +562,12 @@ categorize_data(gen_uc.data, aggregation)
 
 """
 function categorize_data(
-    data::Dict{Symbol, DataFrames.DataFrame},
+    data::Dict{Symbol,DataFrames.DataFrame},
     aggregation::Dict;
     curtailment = true,
     slacks = true,
 )
-    category_dataframes = Dict{String, DataFrames.DataFrame}()
+    category_dataframes = Dict{String,DataFrames.DataFrame}()
     var_types = Dict(
         last(split(string(x), "_")) => x for
         x in keys(data) if !occursin("ActivePowerInVariable", string(x))
@@ -609,7 +602,7 @@ function categorize_data(
     end
     if slacks
         for (slack, slack_name) in BALANCE_SLACKVARS
-            for id in findall(x -> occursin(string(slack), x), string.(keys(data)))
+            for id in findall(x -> occursin(string(nameof(slack)), x), string.(keys(data)))
                 slack_key = collect(keys(data))[id]
                 category_dataframes[slack_name] = data[slack_key]
             end

--- a/src/input_utils.jl
+++ b/src/input_utils.jl
@@ -30,7 +30,7 @@ create_problem_results_dict(data_root, "UC"; populate_system = true)
 
 # See also
 `create_problem_results_dict` is a convenience function that calls public interface in
-[`PowerSimulations.jl`](https://nrel-sienna.github.io/PowerSimulations.jl/stable/). To read
+[`PowerSimulations.jl`](https://sienna-platform.github.io/PowerSimulations.jl/stable/). To read
 one results set, or several of them that are not all in the same parent directory, invoke
 that interface directly as needed:
 

--- a/test/test_builtin_metrics.jl
+++ b/test/test_builtin_metrics.jl
@@ -146,3 +146,18 @@ all_metric_names = filter(x -> getproperty(PowerAnalytics.Metrics, x) isa Metric
     @test isconst(PowerAnalytics.Metrics, metric_name)
     test_metric(Val(metric_name))
 end
+
+# Regression test for https://github.com/Sienna-Platform/PowerAnalytics.jl/issues/54.
+# Computing a `ComponentTimedMetric` over a type-based `ComponentSelector` (the original
+# reproducer was `calc_active_power(make_selector(ThermalStandard), results_uc)`) was
+# reported to hit `StackOverflowError`. The bug is not reproducible on current `main`
+# (the `IS.ComponentSelector` contract guarantees `get_components` returns components, not
+# selectors, so `_compute_one` cannot recurse via dispatch). This test pins the reproducer
+# down explicitly so any future regression of either the IS contract or PowerAnalytics'
+# dispatch chain is caught immediately.
+@testset "Regression: Issue #54 — calc_active_power with ComponentSelector dispatch" begin
+    result = calc_active_power(make_selector(ThermalStandard), results_uc)
+    @test result isa ResultType
+    @test DATETIME_COL in names(result)
+    @test length(get_data_cols(result)) >= 1
+end

--- a/test/test_data/results_data.jl
+++ b/test/test_data/results_data.jl
@@ -1,4 +1,4 @@
-# Will be superseded by https://github.com/NREL-Sienna/PowerSystems.jl/issues/1143
+# Will be superseded by https://github.com/Sienna-Platform/PowerSystems.jl/issues/1143
 function linear_fuel_to_linear_cost(fc::FuelCurve{LinearCurve})
     fuel_cost = get_fuel_cost(fc)
     !(fuel_cost isa Float64) && throw(ArgumentError("fuel_cost must be a scalar"))

--- a/test/test_result_sorting.jl
+++ b/test/test_result_sorting.jl
@@ -141,3 +141,21 @@ end
     sys = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
     @test length(PA.get_load_data(sys; aggregation = ACBus).data) == 3
 end
+
+@testset "Test natural-gas prime-mover categorization" begin
+    mapping = PA.get_generator_mapping()
+    # NG-CT should catch both classic combustion-turbine (CT) and gas-turbine (GT)
+    @test PA.get_generator_category(
+        PSY.ThermalStandard, "NATURAL_GAS", PSY.PrimeMovers.CT, nothing, mapping,
+    ) == "NG-CT"
+    @test PA.get_generator_category(
+        PSY.ThermalStandard, "NATURAL_GAS", PSY.PrimeMovers.GT, nothing, mapping,
+    ) == "NG-CT"
+    # NG-CC should catch combined-cycle (CC) and the steam side (CA) of decomposed CC plants
+    @test PA.get_generator_category(
+        PSY.ThermalStandard, "NATURAL_GAS", PSY.PrimeMovers.CC, nothing, mapping,
+    ) == "NG-CC"
+    @test PA.get_generator_category(
+        PSY.ThermalStandard, "NATURAL_GAS", PSY.PrimeMovers.CA, nothing, mapping,
+    ) == "NG-CC"
+end

--- a/test/test_result_sorting.jl
+++ b/test/test_result_sorting.jl
@@ -141,3 +141,15 @@ end
     sys = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
     @test length(PA.get_load_data(sys; aggregation = ACBus).data) == 3
 end
+
+@testset "Test HydroGen subtypes map to Hydropower" begin
+    mapping = PA.get_generator_mapping()
+    # HydroPumpTurbine advertises primemover=PS; without the HydroGen rule it
+    # would fall through to the generic `{Any, PS, null}` Storage rule.
+    @test PA.get_generator_category(
+        PSY.HydroPumpTurbine, nothing, PSY.PrimeMovers.PS, nothing, mapping,
+    ) == "Hydropower"
+    @test PA.get_generator_category(
+        PSY.HydroTurbine, nothing, PSY.PrimeMovers.HY, nothing, mapping,
+    ) == "Hydropower"
+end

--- a/test/test_result_sorting.jl
+++ b/test/test_result_sorting.jl
@@ -141,3 +141,23 @@ end
     sys = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
     @test length(PA.get_load_data(sys; aggregation = ACBus).data) == 3
 end
+
+@testset "Test make_fuel_dictionary filter_func applies to relevant component types" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5_all_components")
+
+    # Add a Storage component
+    stor = PSY.EnergyReservoirStorage(nothing)
+    PSY.set_bus!(stor, PSY.get_component(PSY.ACBus, sys, "nodeA"))
+    PSY.set_available!(stor, true)
+    PSY.add_component!(sys, stor)
+
+    # Filter out everything → empty result
+    cat_empty = PA.make_fuel_dictionary(sys; filter_func = x -> false)
+    @test all(isempty, values(cat_empty))
+    # Filter to one component of each type and verify exactly one result each time
+    for T in (PSY.StaticLoad, PSY.Generator, PSY.Storage)
+        target = PSY.get_name(first(PSY.get_components(T, sys)))
+        cat_one = PA.make_fuel_dictionary(sys; filter_func = x -> PSY.get_name(x) == target)
+        @test sum(length(v) for v in values(cat_one)) == 1
+    end
+end

--- a/test/test_result_sorting.jl
+++ b/test/test_result_sorting.jl
@@ -3,24 +3,25 @@ problem_results = run_test_prob()
 
 @testset "test filter results" begin
     gen = PA.get_generation_data(results_uc; curtailment = false)
-    @test keys(gen.data) ==
-          Set([:ActivePowerVariable__HydroTurbine,
+    @test keys(gen.data) == Set([
+        :ActivePowerVariable__HydroTurbine,
         :ActivePowerOutVariable__EnergyReservoirStorage,
         :ActivePowerTimeSeriesParameter__RenewableNonDispatch,
         :ActivePowerVariable__RenewableDispatch,
         :ActivePowerInVariable__EnergyReservoirStorage,
         :ActivePowerTimeSeriesParameter__HydroDispatch,
-        :ActivePowerVariable__ThermalStandard])
+        :ActivePowerVariable__ThermalStandard,
+    ])
     @test length(gen.time) == 48
 
     gen = PA.get_generation_data(
         results_uc;
         variable_keys = [
-            PowerSimulations.VariableKey{ActivePowerVariable, ThermalStandard}(""),
-            PowerSimulations.VariableKey{ActivePowerVariable, RenewableDispatch}(""),
+            PowerSimulations.VariableKey{ActivePowerVariable,ThermalStandard}(""),
+            PowerSimulations.VariableKey{ActivePowerVariable,RenewableDispatch}(""),
         ],
         parameter_keys = [
-            PowerSimulations.ParameterKey{ActivePowerTimeSeriesParameter, RenewableDispatch}(
+            PowerSimulations.ParameterKey{ActivePowerTimeSeriesParameter,RenewableDispatch}(
                 "",
             ),
         ],
@@ -38,7 +39,7 @@ problem_results = run_test_prob()
     load = PA.get_load_data(
         results_ed;
         parameter_keys = [
-            PowerSimulations.ParameterKey{ActivePowerTimeSeriesParameter, PowerLoad}(""),
+            PowerSimulations.ParameterKey{ActivePowerTimeSeriesParameter,PowerLoad}(""),
         ],
         initial_time = Dates.DateTime("2020-01-02T02:00:00"),
         len = 3,
@@ -140,4 +141,25 @@ end
     # Test with a system with `DeterministicSingleTimeSeries`
     sys = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
     @test length(PA.get_load_data(sys; aggregation = ACBus).data) == 3
+end
+
+@testset "categorize_data surfaces slack variables" begin
+    ts = collect(
+        Dates.DateTime("2024-01-01T00:00:00"):Dates.Hour(1):Dates.DateTime(
+            "2024-01-01T02:00:00",
+        ),
+    )
+    df_up = DataFrames.DataFrame(; DateTime = ts, var = [1.0, 2.0, 3.0])
+    df_dn = DataFrames.DataFrame(; DateTime = ts, var = [0.5, 1.5, 2.5])
+    data = Dict{Symbol,DataFrames.DataFrame}(
+        :SystemBalanceSlackUp__System => df_up,
+        :SystemBalanceSlackDown__System => df_dn,
+    )
+
+    result = PA.categorize_data(data, Dict())
+
+    @test haskey(result, "Unserved Energy")
+    @test haskey(result, "Over Generation")
+    @test result["Unserved Energy"] === df_up
+    @test result["Over Generation"] === df_dn
 end


### PR DESCRIPTION

Per Jose s request I agrupated mentioned PRs into a single one after review and applying a few little changes then solved conflicts.  Each was previously a standalone branch; this combined branch merges them for this single PR.

## Changes descriptions 

1. **Match slack variables by bare type name** (fix for `categorize_data`)
   - Ensures slack variables like `SystemBalanceSlackUp__System` are recognized regardless of suffixes.
   - Adds a test: `categorize_data surfaces slack variables`.

2. **Regression test for Issue #54**
   - Adds an explicit test for `calc_active_power(make_selector(ThermalStandard), results_uc)` to prevent regressions related to `ComponentSelector` dispatch.
   - The original bug is not reproducible on current `main`; the test pins the reproducer for future safety.

3. **Narrow `make_fuel_dictionary` to fuel-bearing component types**
   - Restricts the function to `StaticLoad`, `Generator`, and `Storage`, excluding non-fuel types.
   - Adds a test validating `filter_func` behavior across types.

4. **Extend natural-gas prime-mover mapping** (`deps/generator_mapping.yaml`)
   - `NG-CT` also matches `GT` (gas turbine) in addition to `CT`.
   - `NG-CC` also matches `CA` (steam side) in addition to `CC`.
   - Adds tests asserting mapping correctness.

5. **Map all `HydroGen` subtypes to `Hydropower`**
   - Adds a `{gentype: HydroGen, primemover: null, fuel: null}` rule so `HydroPumpTurbine` and `HydroTurbine` categorize as `Hydropower`.
   - Lookup uses type-hierarchy-aware matching, so this rule fires before generic `Any` fallbacks.

## Verification

- Full test suite: **790 / 790 tests passed**.

## Included PRs and related issues

| # | Title | Status |
|---|-------|--------|
| PR #64 | Map all HydroGen subtypes to Hydropower | Included |
| PR #65 | Subtype `make_fuel_dictionary` to appropriate types | Included |
| PR #66 | Fix default generator mapping file (NG-CT/NG-CC) | Included |
| Issue #46 | `categorize_data` misses slack variables | Closes |
| Issue #54 | `StackOverflowError` for `calc_active_power` with `make_selector` | Closes — regression test pins reproducer |