### PR TITLE
Add docs content and ensure all exported items have docstrings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,9 +27,14 @@ pages = OrderedDict(
     "Tutorials" => Any[
         "Simulation Scenarios Analysis" => "tutorials/generated_PA_workflow_tutorial.md",
     ],
-    # TODO flesh out the how-tos, explanation
-    # "How to..." => Any[#="stub" => "how_to_guides/stub.md"=#],
-    # "Explanation" => Any[#="stub" => "explanation/stub.md"=#],
+    "How to..." => Any[
+        "How to group generation by fuel or technology category" => "how_to_guides/how_to_group_generation_by_fuel.md",
+        "How to define a custom metric" => "how_to_guides/how_to_define_a_custom_metric.md",
+    ],
+    "Explanation" => Any[
+        "How `PowerAnalytics` thinks" => "explanation/metrics_and_component_selectors.md",
+        "Choosing built-in metrics" => "explanation/choosing_built_in_metrics.md",
+    ],
     "Reference" => Any[
         "Public API" => "reference/public.md",
         "Developers" => ["Developer Guidelines" => "reference/developer_guidelines.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,7 +29,7 @@ pages = OrderedDict(
         "Simulation Scenarios Analysis" => "tutorials/generated_PA_workflow_tutorial.md",
     ],
     "How to..." => Any[
-        "How to group generation by fuel or technology category" => "how_to_guides/how_to_group_generation_by_fuel.md",
+        "How to group generation by category" => "how_to_guides/how_to_group_generation_by_fuel.md",
         "How to define a custom metric" => "how_to_guides/how_to_define_a_custom_metric.md",
     ],
     "Explanation" => Any[

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,8 @@ links = InterLinks(
     "PowerSystems" => "https://sienna-platform.github.io/PowerSystems.jl/stable/",
     "PowerSimulations" => "https://sienna-platform.github.io/PowerSimulations.jl/stable/",
     "StorageSystemsSimulations" => "https://sienna-platform.github.io/StorageSystemsSimulations.jl/stable/",
-    "HydroPowerSimulations" => "https://sienna-platform.github.io/HydroPowerSimulations.jl/dev/",
+    "HydroPowerSimulations" => "https://sienna-platform.github.io/HydroPowerSimulations.jl/stable/",
+    "PowerGraphics" => "https://sienna-platform.github.io/PowerGraphics.jl/stable/",
 )
 
 include(joinpath(@__DIR__, "make_tutorials.jl"))

--- a/docs/src/explanation/choosing_built_in_metrics.md
+++ b/docs/src/explanation/choosing_built_in_metrics.md
@@ -10,9 +10,9 @@ keys, and aggregation details are in each metric's docstring on
 
 ## Curtailment: absolute versus fraction
 
-| Metric | Use when |
-|:-------|:---------|
-| [`calc_curtailment`](@ref PowerAnalytics.Metrics.calc_curtailment) | You need energy (or MW-step) of unused availability: forecast minus dispatch |
+| Metric                                                                       | Use when                                                                                           |
+|:---------------------------------------------------------------------------- |:-------------------------------------------------------------------------------------------------- |
+| [`calc_curtailment`](@ref PowerAnalytics.Metrics.calc_curtailment)           | You need energy (or MW-step) of unused availability: forecast minus dispatch                       |
 | [`calc_curtailment_frac`](@ref PowerAnalytics.Metrics.calc_curtailment_frac) | You need a rate relative to available power; time/component averages should weight by availability |
 
 Both require forecast parameters and active-power variables on the selector. Prefer the
@@ -21,10 +21,10 @@ periods with different available capacity.
 
 ## Integration versus capacity factor
 
-| Metric | Numerator | Denominator | Typical question |
-|:-------|:----------|:------------|:-----------------|
-| [`calc_integration`](@ref PowerAnalytics.Metrics.calc_integration) | Realized [`calc_active_power`](@ref PowerAnalytics.Metrics.calc_active_power) | System load forecast + storage-as-load | What share of demand did this fleet serve? |
-| [`calc_capacity_factor`](@ref PowerAnalytics.Metrics.calc_capacity_factor) | [`calc_active_power_forecast`](@ref PowerAnalytics.Metrics.calc_active_power_forecast) | Component rating | Does forecast/rating look plausible? |
+| Metric                                                                     | Numerator                                                                              | Denominator                            | Typical question                           |
+|:-------------------------------------------------------------------------- |:-------------------------------------------------------------------------------------- |:-------------------------------------- |:------------------------------------------ |
+| [`calc_integration`](@ref PowerAnalytics.Metrics.calc_integration)         | Realized [`calc_active_power`](@ref PowerAnalytics.Metrics.calc_active_power)          | System load forecast + storage-as-load | What share of demand did this fleet serve? |
+| [`calc_capacity_factor`](@ref PowerAnalytics.Metrics.calc_capacity_factor) | [`calc_active_power_forecast`](@ref PowerAnalytics.Metrics.calc_active_power_forecast) | Component rating                       | Does forecast/rating look plausible?       |
 
 Integration is a **system demand** share (and can exceed a naive “generation / load” story
 when storage charging is in the denominator). Capacity factor here is **not** realized
@@ -35,11 +35,11 @@ For a classical realized capacity factor, compose or define a metric that divide
 
 ## Cost family
 
-| Metric | Meaning |
-|:-------|:--------|
-| [`calc_production_cost`](@ref PowerAnalytics.Metrics.calc_production_cost) | Production-cost expression from the solver |
-| [`calc_startup_cost`](@ref PowerAnalytics.Metrics.calc_startup_cost) / [`calc_shutdown_cost`](@ref PowerAnalytics.Metrics.calc_shutdown_cost) | Commitment start/stop binaries times cost coefficients |
-| [`calc_total_cost`](@ref PowerAnalytics.Metrics.calc_total_cost) | **Currently an alias of production cost** — does not add start/stop |
+| Metric                                                                                                                                        | Meaning                                                             |
+|:--------------------------------------------------------------------------------------------------------------------------------------------- |:------------------------------------------------------------------- |
+| [`calc_production_cost`](@ref PowerAnalytics.Metrics.calc_production_cost)                                                                    | Production-cost expression from the solver                          |
+| [`calc_startup_cost`](@ref PowerAnalytics.Metrics.calc_startup_cost) / [`calc_shutdown_cost`](@ref PowerAnalytics.Metrics.calc_shutdown_cost) | Commitment start/stop binaries times cost coefficients              |
+| [`calc_total_cost`](@ref PowerAnalytics.Metrics.calc_total_cost)                                                                              | **Currently an alias of production cost** — does not add start/stop |
 
 Sum production, startup, and shutdown yourself when you need a full commitment cost. Not
 every component cost type defines start/stop coefficients.

--- a/docs/src/explanation/choosing_built_in_metrics.md
+++ b/docs/src/explanation/choosing_built_in_metrics.md
@@ -1,0 +1,58 @@
+# [Choosing built-in metrics](@id choosing_built_in_metrics)
+
+```@meta
+CurrentModule = PowerAnalytics
+```
+
+Built-in metrics live in [`PowerAnalytics.Metrics`](@ref). Exact formulas, PowerSimulations
+keys, and aggregation details are in each metric's docstring on
+[Built-in Metrics](@ref Built-in-Metrics). This page compares when to reach for which one.
+
+## Curtailment: absolute versus fraction
+
+| Metric | Use when |
+|:-------|:---------|
+| [`calc_curtailment`](@ref PowerAnalytics.Metrics.calc_curtailment) | You need energy (or MW-step) of unused availability: forecast minus dispatch |
+| [`calc_curtailment_frac`](@ref PowerAnalytics.Metrics.calc_curtailment_frac) | You need a rate relative to available power; time/component averages should weight by availability |
+
+Both require forecast parameters and active-power variables on the selector. Prefer the
+absolute metric for energy balances and totals; prefer the fraction when comparing units or
+periods with different available capacity.
+
+## Integration versus capacity factor
+
+| Metric | Numerator | Denominator | Typical question |
+|:-------|:----------|:------------|:-----------------|
+| [`calc_integration`](@ref PowerAnalytics.Metrics.calc_integration) | Realized [`calc_active_power`](@ref PowerAnalytics.Metrics.calc_active_power) | System load forecast + storage-as-load | What share of demand did this fleet serve? |
+| [`calc_capacity_factor`](@ref PowerAnalytics.Metrics.calc_capacity_factor) | [`calc_active_power_forecast`](@ref PowerAnalytics.Metrics.calc_active_power_forecast) | Component rating | Does forecast/rating look plausible? |
+
+Integration is a **system demand** share (and can exceed a naive “generation / load” story
+when storage charging is in the denominator). Capacity factor here is **not** realized
+production over rating — it deliberately uses the forecast parameter as a sanity check.
+For a classical realized capacity factor, compose or define a metric that divides
+[`calc_active_power`](@ref PowerAnalytics.Metrics.calc_active_power) by rating (see
+[How to define a custom metric](@ref define_custom_metric)).
+
+## Cost family
+
+| Metric | Meaning |
+|:-------|:--------|
+| [`calc_production_cost`](@ref PowerAnalytics.Metrics.calc_production_cost) | Production-cost expression from the solver |
+| [`calc_startup_cost`](@ref PowerAnalytics.Metrics.calc_startup_cost) / [`calc_shutdown_cost`](@ref PowerAnalytics.Metrics.calc_shutdown_cost) | Commitment start/stop binaries times cost coefficients |
+| [`calc_total_cost`](@ref PowerAnalytics.Metrics.calc_total_cost) | **Currently an alias of production cost** — does not add start/stop |
+
+Sum production, startup, and shutdown yourself when you need a full commitment cost. Not
+every component cost type defines start/stop coefficients.
+
+## Weighted aggregation
+
+Curtailment fraction, integration (in time), and capacity factor attach `agg_meta` weights so
+[`aggregate_time`](@ref) and multi-component reductions are not simple unweighted means.
+If a summary looks “too small” or “too large” relative to a hand-built mean, check the
+metric docstring for `weighted_mean` / `unweighted_sum` behavior.
+
+## Related
+
+  - [Metrics and ComponentSelectors](@ref metrics_and_selectors)
+  - [Built-in Metrics](@ref Built-in-Metrics)
+  - [Simulation Scenarios Analysis](@ref Scenarios_PA_tutorial)

--- a/docs/src/explanation/metrics_and_component_selectors.md
+++ b/docs/src/explanation/metrics_and_component_selectors.md
@@ -1,0 +1,68 @@
+# [How `PowerAnalytics` thinks](@id metrics_and_selectors)
+
+```@meta
+CurrentModule = PowerAnalytics
+```
+
+PowerAnalytics post-processing is organized around two ideas: a [`Metric`](@ref) that
+defines *what* to compute from simulation results, and a
+[`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) that
+defines *which* devices (or groups of devices) that quantity applies to. The
+[Simulation Scenarios Analysis](@ref Scenarios_PA_tutorial) tutorial shows how to call this
+API; this page explains why it is shaped that way.
+
+## Metric plus selector
+
+A [`Metric`](@ref) encapsulates:
+
+  - how to read or derive a quantity from an [`InfrastructureSystems.Results`](@extref)
+    object (often a [`PowerSimulations.SimulationProblemResults`](@extref))
+  - default aggregation across components and across time
+
+Many metrics also need a selector. Calling a metric is syntactic sugar for [`compute`](@ref):
+
+```julia
+using PowerAnalytics.Metrics
+calc_active_power(make_selector(RenewableDispatch), results)
+# same as:
+compute(calc_active_power, results, make_selector(RenewableDispatch))
+```
+
+[`make_selector`](@extref PowerSystems InfrastructureSystems.make_selector) and
+[`rebuild_selector`](@extref PowerSystems InfrastructureSystems.rebuild_selector-Tuple{InfrastructureSystems.ListComponentSelector})
+come from InfrastructureSystems (exported by PowerSystems). They control grouping: one
+column per component by default, or collapsed groups via `groupby` (for example
+`groupby = :all` or a function such as `get_prime_mover_type`).
+
+System-wide and results-wide metrics omit the selector. Examples:
+[`calc_system_slack_up`](@ref PowerAnalytics.Metrics.calc_system_slack_up) and
+[`calc_sum_objective_value`](@ref PowerAnalytics.Metrics.calc_sum_objective_value).
+
+## Timed versus timeless
+
+| Kind | Role | Typical output |
+|:-----|:-----|:---------------|
+| [`TimedMetric`](@ref) | Values indexed by simulation time | `DataFrame` with a `DateTime` column |
+| [`TimelessMetric`](@ref) | One summary per results object | Scalar (or one-row frame) |
+
+Most built-ins under [`PowerAnalytics.Metrics`](@ref) are timed and component-scoped
+([`ComponentTimedMetric`](@ref)). Optimizer statistics such as objective value and solve
+time are timeless. [`compute_all`](@ref) and [`aggregate_time`](@ref) are the usual way to
+combine timed series and then collapse time for scenario tables; see the tutorial.
+
+## Aggregation is part of the metric
+
+When a selector has multiple components in a group, the metric's `component_agg_fn` reduces
+them (default [`sum`](@extref Base.sum)). When you call [`aggregate_time`](@ref), the
+metric's `time_agg_fn` reduces the time axis (also default `sum`).
+
+Some metrics attach **aggregation metadata** (`agg_meta`) so those reductions can be
+weighted — for example curtailment fraction weights by available power. Changing defaults
+without rewriting the evaluation function is the job of [`rebuild_metric`](@ref). Composing
+existing metrics with an elementwise function is the job of [`compose_metrics`](@ref).
+
+For task-oriented recipes, see [How to define a custom metric](@ref define_custom_metric)
+and [How to group generation by fuel or technology category](@ref group_generation_by_fuel).
+For formulas and caveats on specific built-ins, see
+[Choosing built-in metrics](@ref choosing_built_in_metrics) and the
+[Built-in Metrics](@ref Built-in-Metrics) reference.

--- a/docs/src/explanation/metrics_and_component_selectors.md
+++ b/docs/src/explanation/metrics_and_component_selectors.md
@@ -40,10 +40,10 @@ System-wide and results-wide metrics omit the selector. Examples:
 
 ## Timed versus timeless
 
-| Kind | Role | Typical output |
-|:-----|:-----|:---------------|
-| [`TimedMetric`](@ref) | Values indexed by simulation time | `DataFrame` with a `DateTime` column |
-| [`TimelessMetric`](@ref) | One summary per results object | Scalar (or one-row frame) |
+| Kind                     | Role                              | Typical output                       |
+|:------------------------ |:--------------------------------- |:------------------------------------ |
+| [`TimedMetric`](@ref)    | Values indexed by simulation time | `DataFrame` with a `DateTime` column |
+| [`TimelessMetric`](@ref) | One summary per results object    | Scalar (or one-row frame)            |
 
 Most built-ins under [`PowerAnalytics.Metrics`](@ref) are timed and component-scoped
 ([`ComponentTimedMetric`](@ref)). Optimizer statistics such as objective value and solve

--- a/docs/src/explanation/metrics_and_component_selectors.md
+++ b/docs/src/explanation/metrics_and_component_selectors.md
@@ -62,7 +62,7 @@ without rewriting the evaluation function is the job of [`rebuild_metric`](@ref)
 existing metrics with an elementwise function is the job of [`compose_metrics`](@ref).
 
 For task-oriented recipes, see [How to define a custom metric](@ref define_custom_metric)
-and [How to group generation by fuel or technology category](@ref group_generation_by_fuel).
+and [How to group generation by category](@ref group_generation_by_fuel).
 For formulas and caveats on specific built-ins, see
 [Choosing built-in metrics](@ref choosing_built_in_metrics) and the
 [Built-in Metrics](@ref Built-in-Metrics) reference.

--- a/docs/src/explanation/stub.md
+++ b/docs/src/explanation/stub.md
@@ -1,3 +1,0 @@
-## Explanation
-
-Refer here to find context and further explanation of the workings of `PowerAnalytics`. This is still under construction, check for more here soon!

--- a/docs/src/how_to_guides/how_to_define_a_custom_metric.md
+++ b/docs/src/how_to_guides/how_to_define_a_custom_metric.md
@@ -1,0 +1,82 @@
+# [How to define a custom metric](@id define_custom_metric)
+
+```@meta
+CurrentModule = PowerAnalytics
+```
+
+Extend PowerAnalytics by composing existing metrics, changing aggregation defaults, or
+writing a [`ComponentTimedMetric`](@ref) with a custom `eval_fn`. Prefer the smallest
+extension that fits; most cases do not need a new subtype of [`Metric`](@ref).
+
+## Compose existing metrics
+
+[`compose_metrics`](@ref) builds a new metric that evaluates several inputs and reduces them
+with a function (elementwise on timed columns):
+
+```julia
+using PowerAnalytics.Metrics
+
+# Same pattern as the built-in calc_load_from_storage
+const calc_net_storage_power = compose_metrics(
+    "NetStoragePower",
+    (-),
+    calc_active_power_out,
+    calc_active_power_in,
+)
+
+calc_net_storage_power(make_selector(EnergyReservoirStorage; groupby = :all), results)
+```
+
+You can mix [`ComponentSelectorTimedMetric`](@ref) and [`SystemTimedMetric`](@ref) inputs;
+system metrics are treated as applying to the same selector context. Do not mix timed and
+timeless metrics in one composition.
+
+## Change aggregation with `rebuild_metric`
+
+[`rebuild_metric`](@ref) copies a metric and overrides fields such as `component_agg_fn` or
+`time_agg_fn`:
+
+```julia
+using PowerAnalytics.Metrics
+using Statistics: mean
+
+const calc_active_power_mean = rebuild_metric(calc_active_power; component_agg_fn = mean)
+calc_active_power_mean(make_selector(ThermalStandard), results)
+```
+
+Use this when the evaluation logic is correct but defaults (usually `sum`) are not.
+
+## Define a `ComponentTimedMetric` from scratch
+
+When you need per-component logic that is not a simple composition, construct a
+[`ComponentTimedMetric`](@ref):
+
+```julia
+using PowerAnalytics
+using PowerAnalytics.Metrics
+
+const calc_active_power_gw = ComponentTimedMetric(;
+    name = "ActivePowerGW",
+    eval_fn = (res, comp; kwargs...) -> begin
+        val = compute(calc_active_power, res, comp; kwargs...)
+        get_data_vec(val) ./= 1000
+        return val
+    end,
+)
+```
+
+`eval_fn` receives `(results, component; start_time, len, …)` and must return a timed
+`DataFrame` (with a `DateTime` column). Optional fields include `component_agg_fn`,
+`time_agg_fn`, and `eval_zero` for empty groups. For selector-level evaluation without
+drilling to each [`PowerSystems.Component`](@extref), use [`CustomTimedMetric`](@ref). For
+system-wide quantities, use [`SystemTimedMetric`](@ref).
+
+If you only wrap a PowerSimulations results entry type, construct a
+[`ComponentTimedMetric`](@ref) whose `eval_fn` calls the package's results readers (the same
+pattern as many built-ins in [`PowerAnalytics.Metrics`](@ref)).
+
+## Related
+
+  - [Metrics and ComponentSelectors](@ref metrics_and_selectors)
+  - [Advanced Metrics Interface](@ref Advanced-Metrics-Interface) in the public API
+  - [Built-in Metrics](@ref Built-in-Metrics)

--- a/docs/src/how_to_guides/how_to_group_generation_by_fuel.md
+++ b/docs/src/how_to_guides/how_to_group_generation_by_fuel.md
@@ -35,7 +35,7 @@ keys(generator_categories)
 
 ## Point at a custom mapping file
 
-Package defaults load
+By default, the package loads
 [`deps/generator_mapping.yaml`](https://github.com/Sienna-Platform/PowerAnalytics.jl/blob/main/deps/generator_mapping.yaml)
 shipped with PowerAnalytics. To build selectors from your own YAML:
 

--- a/docs/src/how_to_guides/how_to_group_generation_by_fuel.md
+++ b/docs/src/how_to_guides/how_to_group_generation_by_fuel.md
@@ -1,0 +1,61 @@
+# [How to group generator categories](@id group_generation_by_fuel)
+
+```@meta
+CurrentModule = PowerAnalytics
+```
+
+Use the built-in selectors from [`PowerAnalytics.Selectors`](@ref) when you want Metric API
+results grouped by fuel or technology categories from
+[`deps/generator_mapping.yaml`](https://github.com/Sienna-Platform/PowerAnalytics.jl/blob/main/deps/generator_mapping.yaml),
+instead of by component type alone.
+
+## Use the built-in categorized selector
+
+```julia
+using PowerAnalytics
+using PowerAnalytics.Metrics
+using PowerAnalytics.Selectors
+
+# One column per category present in the results' system (PV, Wind, Coal, …)
+calc_active_power(categorized_generators, results)
+```
+
+[`categorized_generators`](@ref PowerAnalytics.Selectors.categorized_generators) is a single
+[`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) whose
+groups are the generator categories in the default mapping (storage and load categories are
+excluded). For injectors including storage and sources, use
+[`categorized_injectors`](@ref PowerAnalytics.Selectors.categorized_injectors).
+
+To inspect the dictionary of per-category selectors:
+
+```julia
+generator_categories  # Dict{String, ComponentSelector}
+keys(generator_categories)
+```
+
+## Point at a custom mapping file
+
+Package defaults load
+[`deps/generator_mapping.yaml`](https://github.com/Sienna-Platform/PowerAnalytics.jl/blob/main/deps/generator_mapping.yaml)
+shipped with PowerAnalytics. To build selectors from your own YAML:
+
+```julia
+cats = parse_generator_categories("/path/to/generator_mapping.yaml")
+sel = make_selector(values(cats)...)
+calc_active_power(sel, results)
+```
+
+Use [`parse_injector_categories`](@ref) when you want every top-level category in the file,
+including those listed under `__META.non_generators`. See
+[`parse_generator_mapping_file`](@ref) for the full parse (selectors plus metadata).
+
+YAML entries match on `gentype`, `primemover`, and `fuel` (PowerSystems enums). Category
+names should stay consistent with any downstream color palettes (for example
+[`PowerGraphics.plot_fuel`](@extref)).
+
+## Related
+
+  - Mental model: [Metrics and ComponentSelectors](@ref metrics_and_selectors)
+  - Legacy PowerData path for stacked fuel plots:
+    [How to build fuel-stacked generation data for plotting](@ref fuel_stacked_generation_data)
+  - Selector reference: [Built-in Selectors](@ref Built-in-Selectors)

--- a/docs/src/how_to_guides/how_to_group_generation_by_fuel.md
+++ b/docs/src/how_to_guides/how_to_group_generation_by_fuel.md
@@ -1,4 +1,4 @@
-# [How to group generator categories](@id group_generation_by_fuel)
+# [How to group generation by category](@id group_generation_by_fuel)
 
 ```@meta
 CurrentModule = PowerAnalytics
@@ -49,13 +49,16 @@ Use [`parse_injector_categories`](@ref) when you want every top-level category i
 including those listed under `__META.non_generators`. See
 [`parse_generator_mapping_file`](@ref) for the full parse (selectors plus metadata).
 
-YAML entries match on `gentype`, `primemover`, and `fuel` (PowerSystems enums). Category
+YAML entries match on `gentype` (a [`PowerSystems.Component`](@extref) type name),
+`primemover`
+([`PowerSystems.PrimeMovers`](@extref PowerSystems.PrimeMoversModule.PrimeMovers)), and
+`fuel`
+([`PowerSystems.ThermalFuels`](@extref PowerSystems.ThermalFuelsModule.ThermalFuels)).
+Category
 names should stay consistent with any downstream color palettes (for example
-[`PowerGraphics.plot_fuel`](@extref)).
+[`PowerGraphics.load_palette`](@extref)).
 
 ## Related
 
   - Mental model: [Metrics and ComponentSelectors](@ref metrics_and_selectors)
-  - Legacy PowerData path for stacked fuel plots:
-    [How to build fuel-stacked generation data for plotting](@ref fuel_stacked_generation_data)
   - Selector reference: [Built-in Selectors](@ref Built-in-Selectors)

--- a/docs/src/how_to_guides/stub.md
+++ b/docs/src/how_to_guides/stub.md
@@ -1,3 +1,0 @@
-## How-to Guides
-
-How-tos can be be referenced when looking for guidance for specific scenarios and issues in `PowerAnalytics`. These are still under construction, check for more here soon!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@
 
 PowerAnalytics.jl is a Julia package designed to support power system simulation results analysis. It relies on results generated from [`PowerSimulations.jl`](https://sienna-platform.github.io/PowerSimulations.jl/stable/) and data structures defined in [`PowerSystems.jl`](https://sienna-platform.github.io/PowerSystems.jl/stable/). PowerAnalytics also provides the data collection, aggregation, and subsetting for [`PowerGraphics.jl`](https://sienna-platform.github.io/PowerGraphics.jl/stable/).
 
-The tutorial, how-to, and explanation sections of the documentation are still under construction; the most informative section is the [public API reference](reference/public.md). PowerAnalytics depends heavily on the `ComponentSelector` feature of PowerSystems.jl, documented [here](https://sienna-platform.github.io/PowerSystems.jl/stable/api/public/#InfrastructureSystems.ComponentSelector).
+The how-to and explanation sections of the documentation are still under construction. See the [Simulation Scenarios Analysis](@ref Scenarios_PA_tutorial) tutorial and the [public API reference](reference/public.md). PowerAnalytics depends heavily on [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector), an InfrastructureSystems type exported by PowerSystems.
 
 ## Installation
 
@@ -16,11 +16,10 @@ The latest stable release of PowerAnalytics can be installed using the Julia pac
 
 !!! note
     
-    The latest stable release of `PowerAnalytics.jl` supports the `PowerSystems.jl` 5.0
+    The latest stable release of `PowerAnalytics.jl` supports the `PowerSystems.jl` 5.x
     ecosystem, except that all results processing is done in wide format rather than long
-    format, which precludes support for greater than two dimensional results. For now,
-    greater than two dimensional results must be processed manually; we are working to add
-    support for these in a future release.
+    format, which precludes support for greater than two dimensional results. Greater than
+    two dimensional results must be processed manually.
 
 ## About Sienna
 
@@ -32,7 +31,7 @@ power system modeling, simulation, and optimization. The Sienna ecosystem can be
   - [Sienna\Data](https://sienna-platform.github.io/Sienna/pages/applications/sienna_data.html) enables
     efficient data input, analysis, and transformation
   - [Sienna\Ops](https://sienna-platform.github.io/Sienna/pages/applications/sienna_ops.html) enables
-    enables system scheduling simulations by formulating and solving optimization problems
+    system scheduling simulations by formulating and solving optimization problems
   - [Sienna\Dyn](https://sienna-platform.github.io/Sienna/pages/applications/sienna_dyn.html) enables
     system transient analysis including small signal stability and full system dynamic
     simulations

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-PowerAnalytics.jl is a Julia package designed to support power system simulation results analysis. It relies on results generated from [`PowerSimulations.jl`](https://sienna-platform.github.io/PowerSimulations.jl/stable/) and data structures defined in [`PowerSystems.jl`](https://sienna-platform.github.io/PowerSystems.jl/stable/). PowerAnalytics also provides the data collection, aggregation, and subsetting for [`PowerGraphics.jl`](https://sienna-platform.github.io/PowerGraphics.jl/stable/).
+PowerAnalytics.jl is a Julia package designed to support power system simulation results analysis. It relies on results generated from [`PowerSimulations.jl`](https://sienna-platform.github.io/PowerSimulations.jl/stable/) and data structures defined in [`PowerSystems.jl`](https://sienna-platform.github.io/PowerSystems.jl/stable/). PowerAnalytics also provides the data collection, aggregation, and subsetting for
+[PowerGraphics.jl](https://sienna-platform.github.io/PowerGraphics.jl/stable/).
 
-The how-to and explanation sections of the documentation are still under construction. See the [Simulation Scenarios Analysis](@ref Scenarios_PA_tutorial) tutorial and the [public API reference](reference/public.md). PowerAnalytics depends heavily on [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector), an InfrastructureSystems type exported by PowerSystems.
+See the [Simulation Scenarios Analysis](@ref Scenarios_PA_tutorial) tutorial, the how-to and explanation sections, and the [public API reference](reference/public.md). PowerAnalytics depends heavily on [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector), an InfrastructureSystems type exported by PowerSystems.
 
 ## Installation
 

--- a/docs/src/reference/developer_guidelines.md
+++ b/docs/src/reference/developer_guidelines.md
@@ -4,8 +4,8 @@ In order to contribute to `PowerAnalytics.jl` repository please read the followi
 [`InfrastructureSystems.jl`](https://sienna-platform.github.io/InfrastructureSystems.jl/stable/) and [`SiennaTemplate.jl`](https://github.com/Sienna-Platform/SiennaTemplate.jl)
 documentation in detail:
 
- 1. [Style Guide](https://sienna-platform.github.io/InfrastructureSystems.jl/stable/style/)
- 2. [Documentation Best Practices](https://sienna-platform.github.io/InfrastructureSystems.jl/stable/docs_best_practices/explanation/)
+ 1. [Style Guide](@extref InfrastructureSystems :doc:`style`)
+ 2. [Documentation Best Practices](@extref InfrastructureSystems :doc:`docs_best_practices/explanation`)
  3. [Contributing Guidelines](https://github.com/Sienna-Platform/SiennaTemplate.jl/blob/main/CONTRIBUTING.md)
 
 Pull requests are always welcome to fix bugs or add additional modeling capabilities.

--- a/docs/src/reference/public.md
+++ b/docs/src/reference/public.md
@@ -2,9 +2,8 @@
 
 ## `ComponentSelector`
 
-PowerAnalytics depends heavily on the `ComponentSelector` feature of PowerSystems.jl.
-`ComponentSelector` documentation can be found
-[here](https://sienna-platform.github.io/PowerSystems.jl/stable/api/public/#InfrastructureSystems.ComponentSelector).
+PowerAnalytics depends heavily on [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector),
+an InfrastructureSystems type exported by PowerSystems.
 PowerAnalytics provides some [built-in selectors](@ref Built-in-Selectors), but much of the
 power of PowerAnalytics comes from the ability to operate on custom `ComponentSelector`s.
 

--- a/docs/src/tutorials/PA_workflow_tutorial.jl
+++ b/docs/src/tutorials/PA_workflow_tutorial.jl
@@ -43,7 +43,7 @@
 #
 # !!! info
 #
-#     More information regarding the different formulations can be found in the [`PowerSimulations.jl` Formulation Library](https://sienna-platform.github.io/PowerSimulations.jl/stable/formulation_library/Introduction/).
+#     More information regarding the different formulations can be found in the [`PowerSimulations.jl` Formulation Library](@extref PowerSimulations :doc:`formulation_library/Introduction`).
 #
 # We document the above here for completeness, since those will directly define the structure of the optimization problem and consequently its auxiliary variables, expressions, parameters and variables for which realized result values are available.
 #
@@ -88,7 +88,7 @@ results_uc = results_all["Scenario_1"]
 #
 # After confirming that the key `ActivePowerVariable__ThermalStandard` is present among the realized variables, we can now extract the generation time series for all the thermal ([`ThermalStandard`](@extref)) generators in our system. To achieve this, we follow two steps:
 #
-#  1. Create a [`ComponentSelector`](@extref InfrastructureSystems.ComponentSelector) that identifies the component type we are interested in (in this case [`ThermalStandard`](@extref)), similarly to how one would call [`get_components`](@extref PowerSystems.get_components).
+#  1. Create a [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) that identifies the component type we are interested in (in this case [`ThermalStandard`](@extref)), similarly to how one would call [`get_components`](@extref PowerSystems.get_components).
 
 thermal_standard_selector = make_selector(ThermalStandard)
 
@@ -97,30 +97,30 @@ thermal_standard_selector = make_selector(ThermalStandard)
 df = calc_active_power(thermal_standard_selector, results_uc);
 show(df; allcols = true)
 
-# Notice that in the resulting dataframe, each column represents the time series of an individual component. This behavior follows from the default settings of [`make_selector`](@extref InfrastructureSystems.make_selector), since we have not specified any additional arguments to modify the default grouping.
+# Notice that in the resulting dataframe, each column represents the time series of an individual component. This behavior follows from the default settings of [`make_selector`](@extref PowerSystems InfrastructureSystems.make_selector), since we have not specified any additional arguments to modify the default grouping.
 #
 # It is also important to keep in mind that by default, only the available components of the system will be included in the resulting dataframe.
 #
 # !!! info
 #
-#     For a complete list of the `PowerAnalytics.jl` built-in metrics, please refer to: [PowerAnalytics Built-In Metrics](https://sienna-platform.github.io/PowerAnalytics.jl/stable/reference/public/#Built-in-Metrics).
+#     For a complete list of the `PowerAnalytics.jl` built-in metrics, please refer to: [PowerAnalytics Built-In Metrics](@ref Built-in-Metrics).
 #
 # ### Obtain the thermal generation time series grouped by prime_mover
 #
 # In some cases, it is more insightful to aggregate generation by `prime_mover_type`, in order to better understand the relative contributions of different generation technologies across the system.
 #
-# To achieve this, we modify our [`ComponentSelector`](@extref InfrastructureSystems.ComponentSelector) using [`rebuild_selector`](@extref InfrastructureSystems.rebuild_selector-Tuple{InfrastructureSystems.ListComponentSelector}), specifying `groupby = get_prime_mover_type`. This restructures the [`ComponentSelector`](@extref InfrastructureSystems.ComponentSelector) so that thermal generators with the same `prime_mover_type` are grouped together.
+# To achieve this, we modify our [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) using [`rebuild_selector`](@extref PowerSystems InfrastructureSystems.rebuild_selector-Tuple{InfrastructureSystems.ListComponentSelector}), specifying `groupby = get_prime_mover_type`. This restructures the [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) so that thermal generators with the same `prime_mover_type` are grouped together.
 
 thermal_standard_selector_pm =
     rebuild_selector(thermal_standard_selector; groupby = get_prime_mover_type)
 
-# Once we have this new [`ComponentSelector`](@extref InfrastructureSystems.ComponentSelector), we use the same metric defined in the previous subsection to compute the aggregated generation time series for each unique `prime_mover_type`.
+# Once we have this new [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector), we use the same metric defined in the previous subsection to compute the aggregated generation time series for each unique `prime_mover_type`.
 
 calc_active_power(thermal_standard_selector_pm, results_uc)
 
 # ### Identify the day of the week with the highest total thermal generation across the entire system
 #
-# To identify the day of the week with the highest total thermal generation across the system, we begin by creating a [`ComponentSelector`](@extref InfrastructureSystems.ComponentSelector) that aggregates all [`ThermalStandard`](@extref) components into a single group. This is done by setting `groupby = :all` in [`make_selector`](@extref InfrastructureSystems.make_selector), which considers all thermal generators as a unified entity and performs the desired spatial aggregation.
+# To identify the day of the week with the highest total thermal generation across the system, we begin by creating a [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) that aggregates all [`ThermalStandard`](@extref) components into a single group. This is done by setting `groupby = :all` in [`make_selector`](@extref PowerSystems InfrastructureSystems.make_selector), which considers all thermal generators as a unified entity and performs the desired spatial aggregation.
 
 thermal_standard_selector_sys = make_selector(ThermalStandard; groupby = :all)
 
@@ -140,12 +140,12 @@ df_day = aggregate_time(sys_active_power; groupby_fn = dayofweek, groupby_col = 
 #
 # In this subsection, we aim to identify the top 10 hours of the month with the highest values of storage charging for each [`Area`](@extref) of the system.
 #
-# To do this, we first define a [`ComponentSelector`](@extref InfrastructureSystems.ComponentSelector) for all [`EnergyReservoirStorage`](@extref) components, but instead of grouping them individually, we group them by the name of the [`Area`](@extref) to which their bus belongs.
+# To do this, we first define a [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) for all [`EnergyReservoirStorage`](@extref) components, but instead of grouping them individually, we group them by the name of the [`Area`](@extref) to which their bus belongs.
 
 storage_area_selector =
     make_selector(EnergyReservoirStorage; groupby = (x -> get_name(get_area(get_bus(x)))))
 
-# Next, using the [`ComponentSelector`](@extref InfrastructureSystems.ComponentSelector) we created, we compute the total active power flowing into the storage components of each [`Area`](@extref) using [`calc_active_power_in`](@ref PowerAnalytics.Metrics.calc_active_power_in), which is another one of `PowerAnalytics.jl` built-in metrics.
+# Next, using the [`ComponentSelector`](@extref PowerSystems InfrastructureSystems.ComponentSelector) we created, we compute the total active power flowing into the storage components of each [`Area`](@extref) using [`calc_active_power_in`](@ref PowerAnalytics.Metrics.calc_active_power_in), which is another one of `PowerAnalytics.jl` built-in metrics.
 
 df_charging = calc_active_power_in(storage_area_selector, results_uc)
 
@@ -170,7 +170,7 @@ end
 #   - [`calc_active_power_out`](@ref PowerAnalytics.Metrics.calc_active_power_out): active power output of the storage device
 #   - [`calc_stored_energy`](@ref PowerAnalytics.Metrics.calc_stored_energy): amount of energy stored
 #
-# We can reuse the `storage_area_selector` defined in the previous subsection to perform spatial aggregation by [`Area`](@extref). However, since we need to guarantee that each of the three metrics contributes only a single column to the resulting summary table, we'll adjust the selector's grouping using [`rebuild_selector`](@extref InfrastructureSystems.rebuild_selector-Tuple{InfrastructureSystems.ListComponentSelector}) to aggregate the time series across all storage components in the system, rather than by [`Area`](@extref).
+# We can reuse the `storage_area_selector` defined in the previous subsection to perform spatial aggregation by [`Area`](@extref). However, since we need to guarantee that each of the three metrics contributes only a single column to the resulting summary table, we'll adjust the selector's grouping using [`rebuild_selector`](@extref PowerSystems InfrastructureSystems.rebuild_selector-Tuple{InfrastructureSystems.ListComponentSelector}) to aggregate the time series across all storage components in the system, rather than by [`Area`](@extref).
 
 df = compute_all(results_uc,
     (

--- a/src/PowerAnalytics.jl
+++ b/src/PowerAnalytics.jl
@@ -6,6 +6,7 @@ export get_generation_data
 export get_load_data
 export get_service_data
 export categorize_data
+export combine_categories
 export no_datetime
 
 export ComponentSelector, SingularComponentSelector, PluralComponentSelector

--- a/src/builtin_metrics.jl
+++ b/src/builtin_metrics.jl
@@ -114,13 +114,26 @@ export calc_active_power,
 
 # NOTE ActivePowerVariable is in units of megawatts per simulation time period, so it's
 # actually energy and it makes sense to sum it up.
-"Calculate the active power of the specified `ComponentSelector`"
+"""
+Active power of the specified `ComponentSelector` from
+[`PowerSimulations.ActivePowerVariable`](@extref).
+
+Values are MW over each simulation time step (energy for that step when summed in time).
+Component- and time-aggregation both default to [`sum`](@extref Base.sum).
+"""
 const calc_active_power = make_component_metric_from_entry(
     "ActivePower",
     PSI.ActivePowerVariable,
 )
 
-"Calculate the production cost expression of the specified `ComponentSelector`"
+"""
+Production cost of the specified `ComponentSelector` from
+`PowerSimulations.ProductionCostExpression`.
+
+This is the solver's production-cost expression only (typically variable/fuel cost), not
+startup or shutdown. See [`calc_startup_cost`](@ref), [`calc_shutdown_cost`](@ref), and
+[`calc_total_cost`](@ref).
+"""
 const calc_production_cost = make_component_metric_from_entry(
     "ProductionCost",
     PSI.ProductionCostExpression,
@@ -150,7 +163,13 @@ const calc_load_from_storage = compose_metrics(
     (-),
     calc_active_power_in, calc_active_power_out)
 
-"Fetch the forecast active power of the specified `ComponentSelector`"
+"""
+Forecast / available active power of the specified `ComponentSelector` from
+[`PowerSimulations.ActivePowerTimeSeriesParameter`](@extref).
+
+Used as the availability side of curtailment and as the numerator of
+[`calc_capacity_factor`](@ref) (not realized dispatch).
+"""
 const calc_active_power_forecast = make_component_metric_from_entry(
     "ActivePowerForecast",
     PSI.ActivePowerTimeSeriesParameter,
@@ -188,21 +207,42 @@ const calc_system_load_from_storage = let
     )
 end
 
-"`SystemLoadForecast` minus `ActivePowerForecast` of the given `ComponentSelector`"
+"""
+[`calc_system_load_forecast`](@ref) minus [`calc_active_power_forecast`](@ref) for the
+given `ComponentSelector`.
+
+Uses forecasts (not realized dispatch) so the series can inform storage or other
+ahead-of-time decisions.
+"""
 const calc_net_load_forecast = compose_metrics(
     "NetLoadForecast",
     # (intentionally done with forecast to inform how storage should be used, among other reasons)
     (-),
     calc_system_load_forecast, calc_active_power_forecast)
 
-"Calculate the `ActivePowerForecast` minus the `ActivePower` of the given `ComponentSelector`"
+"""
+Curtailment of the given `ComponentSelector`:
+[`calc_active_power_forecast`](@ref) minus [`calc_active_power`](@ref).
+
+Requires both [`PowerSimulations.ActivePowerTimeSeriesParameter`](@extref) and
+[`PowerSimulations.ActivePowerVariable`](@extref) for the selected components. Positive
+values mean forecast/availability exceeded realized dispatch.
+"""
 const calc_curtailment = compose_metrics(
     "Curtailment",
     (-),
     calc_active_power_forecast, calc_active_power,
 )
 
-"Calculate the curtailment as a fraction of the `ActivePowerForecast` of the given `ComponentSelector`"
+"""
+Curtailment as a fraction of [`calc_active_power_forecast`](@ref) for the given
+`ComponentSelector`:
+``\\mathrm{curtailment} / \\mathrm{ActivePowerForecast}``.
+
+Aggregation metadata (`agg_meta`) stores the forecast power time series. Component- and
+time-aggregation both use [`weighted_mean`](@ref) with those weights, so periods (or units)
+with more available power dominate the average. A weight of `0` cancels a `NaN` value.
+"""
 const calc_curtailment_frac = ComponentTimedMetric(;
     name = "CurtailmentFrac",
     eval_fn = (
@@ -226,7 +266,16 @@ _integration_denoms(res; kwargs...) =
     compute(calc_system_load_forecast, res; kwargs...),
     compute(calc_system_load_from_storage, res; kwargs...)
 
-"Calculate the `ActivePower` of the given `ComponentSelector` over the sum of the `SystemLoadForecast` and the `SystemLoadFromStorage`"
+"""
+Share of system demand met by the given `ComponentSelector`:
+``\\mathrm{ActivePower} / (\\mathrm{SystemLoadForecast} + \\mathrm{SystemLoadFromStorage})``.
+
+The denominator is system-wide load forecast plus load attributed to storage charging
+([`calc_system_load_forecast`](@ref) + [`calc_system_load_from_storage`](@ref)).
+`agg_meta` stores that denominator; time aggregation uses [`weighted_mean`](@ref), while
+component aggregation uses [`unweighted_sum`](@ref) (shares add across units in a group).
+Component metadata is averaged with `mean`.
+"""
 const calc_integration = ComponentTimedMetric(;
     name = "Integration",
     eval_fn = (
@@ -254,7 +303,19 @@ const calc_integration = ComponentTimedMetric(;
     end,
 )
 
-"Calculate the capacity factor (actual production/rated production) of the specified `ComponentSelector`"
+"""
+Capacity factor of the specified `ComponentSelector`:
+``\\mathrm{ActivePowerForecast} / \\mathrm{rating}``.
+
+!!! warning
+
+    Despite the common industry meaning of "capacity factor", this metric uses
+    [`calc_active_power_forecast`](@ref) (availability parameter), **not** realized
+    [`calc_active_power`](@ref). It is intended as a forecast/rating sanity check. Denominator is `PowerSystems.get_rating`.
+
+`agg_meta` repeats each component's rating; component- and time-aggregation use
+[`weighted_mean`](@ref) with those ratings as weights.
+"""
 const calc_capacity_factor = ComponentTimedMetric(;
     name = "CapacityFactor",
     # (intentionally done with forecast to serve as sanity check -- solar capacity factor shouldn't exceed 20%, etc.)
@@ -269,7 +330,13 @@ const calc_capacity_factor = ComponentTimedMetric(;
     ), component_agg_fn = weighted_mean, time_agg_fn = weighted_mean,
 )
 
-"Calculate the startup cost of the specified `ComponentSelector`"
+"""
+Startup cost of the specified `ComponentSelector`:
+[`PowerSimulations.StartVariable`](@extref) times `PowerSystems.get_start_up` on the
+component's operation cost.
+
+Requires a cost type that defines startup cost (for example thermal generation cost).
+"""
 const calc_startup_cost = ComponentTimedMetric(;
     name = "StartupCost",
     eval_fn = (
@@ -282,7 +349,13 @@ const calc_startup_cost = ComponentTimedMetric(;
     ),
 )
 
-"Calculate the shutdown cost of the specified `ComponentSelector`"
+"""
+Shutdown cost of the specified `ComponentSelector`:
+[`PowerSimulations.StopVariable`](@extref) times `PowerSystems.get_shut_down` on the
+component's operation cost.
+
+Requires a cost type that defines shutdown cost (for example thermal generation cost).
+"""
 const calc_shutdown_cost = ComponentTimedMetric(;
     name = "ShutdownCost",
     eval_fn = (
@@ -302,10 +375,29 @@ _has_startup_shutdown_costs(::PSY.MarketBidCost) = true
 _has_startup_shutdown_costs(component::PSY.Component) =
     _has_startup_shutdown_costs(PSY.get_operation_cost(component))
 
-"Calculate the production cost of the specified `ComponentSelector`, which includes the startup and shutdown costs if they are defined"
+"""
+Alias of [`calc_production_cost`](@ref) (production-cost expression only).
+
+!!! warning
+
+    Despite the name, this does **not** add [`calc_startup_cost`](@ref) or
+    [`calc_shutdown_cost`](@ref). Sum those metrics separately if you need a full commitment
+    cost.
+"""
 const calc_total_cost = calc_production_cost
 
-"Calculate the number of discharge cycles a storage device has gone through in the time period"
+"""
+Approximate discharge cycles for storage in the `ComponentSelector`.
+
+Each time step contributes
+``\\mathrm{ActivePowerOutVariable} / (\\mathrm{capacity} \\cdot (\\mathrm{soc\\_max} -
+\\mathrm{soc\\_min}))``,
+using [`PowerSimulations.ActivePowerOutVariable`](@extref),
+`PowerSystems.get_storage_capacity`, and `PowerSystems.get_storage_level_limits`.
+One cycle means discharging from maximum to minimum state of charge (not from full to empty
+unless those limits are 1 and 0). Summing in time accumulates fractional cycles over the
+horizon.
+"""
 const calc_discharge_cycles = ComponentTimedMetric(;
     name = "DischargeCycles",
     # NOTE: here, we define one "cycle" as a discharge from the maximum state of charge to

--- a/src/fuel_results.jl
+++ b/src/fuel_results.jl
@@ -65,26 +65,26 @@ function get_generator_category(
 end
 
 """
-    generators = make_fuel_dictionary(system::PSY.System, mapping::Dict{NamedTuple, String})
-
-This function makes a dictionary of fuel type and the generators associated.
+Build a dictionary from fuel (or custom) category name to generator `(type, name)`
+pairs for `sys`, using `mapping` of `(gentype, fuel, primemover, …)` keys to category
+labels.
 
 # Arguments
-
-  - `sys::PSY.System`: the system that is used to create the results
-  - `results::IS.Results`: results
+ - `sys`: [`PowerSystems.System`](@extref) whose generators are categorized
+ - `mapping`: map from generator attribute `NamedTuple` to category `String`
 
 # Keyword Arguments
-
-  - `categories::Dict{String, NamedTuple}`: if stacking by a different category is desired
+ - `filter_func`: additional component filter (combined with availability)
+ - `generator_mapping_file`: used only by the one-argument method that loads mapping from YAML
 
 # Examples
 
 ```julia
-results = solve_op_model!(OpModel)
 generators = make_fuel_dictionary(sys)
+generators = make_fuel_dictionary(sys, mapping)
 ```
 
+See also [`categorize_data`](@ref).
 """
 function make_fuel_dictionary(
     sys::PSY.System,
@@ -164,6 +164,12 @@ function make_fuel_dictionary(
     return gen_categories
 end
 
+"""
+Build a fuel-category dictionary for `sys` using the default generator mapping file
+(or `generator_mapping_file` from `kwargs`).
+
+See [`make_fuel_dictionary`](@ref) with an explicit `mapping` argument.
+"""
 function make_fuel_dictionary(sys::PSY.System; kwargs...)
     mapping = get_generator_mapping(get(kwargs, :generator_mapping_file, nothing))
     return make_fuel_dictionary(sys, mapping; kwargs...)

--- a/src/get_data.jl
+++ b/src/get_data.jl
@@ -1,7 +1,18 @@
+"""
+Container for time-aligned result tables used by post-processing and plotting.
 
-# the fundamental struct for plotting
+Each entry in `data` is a wide `DataFrame` of component (or
+category) columns for one results key. `time` holds the timestamps shared by those
+tables. Constructed by [`get_generation_data`](@ref), [`get_load_data`](@ref), and
+[`get_service_data`](@ref).
+
+# Fields
+$(TYPEDFIELDS)
+"""
 struct PowerData
+    "Map from results-key symbol to a wide DataFrame of values (no required `DateTime` column)."
     data::Dict{Symbol, DataFrames.DataFrame}
+    "Timestamps aligned with the rows of each DataFrame in `data`."
     time::Union{StepRange{Dates.DateTime}, Vector{Dates.DateTime}}
 end
 
@@ -211,6 +222,11 @@ function get_service_parameter_names(
     return filter_keys
 end
 
+"""
+Return a copy of `df` with the `DateTime` column removed when present.
+
+Useful before arithmetic or aggregation on result tables that still carry timestamps.
+"""
 no_datetime(df::DataFrames.DataFrame) = df[:, propertynames(df) .!== :DateTime]
 
 function add_fixed_parameters!(
@@ -357,6 +373,32 @@ function filter_results!(
     results::R,
 ) where {R <: IS.Results} end
 
+"""
+Extract generation (and optional storage/source) time series from simulation `results`
+into a [`PowerData`](@ref).
+
+Reads active-power variables (and related parameters / aux variables) for injectors,
+optionally including storage, sources, and curtailment columns.
+
+# Arguments
+ - `results`: an [`InfrastructureSystems.Results`](@extref) object (e.g. from PowerSimulations)
+
+# Keyword Arguments
+ - `filter_func::Union{Function, Nothing} = nothing`: component filter applied when
+   selecting columns; `nothing` keeps all available components
+ - `initial_time` / `start_time`: start of the realized window (default: results metadata)
+ - `horizon` / `len`: number of time steps to read
+ - `variable_keys`, `parameter_keys`, `aux_variable_keys`: override which optimization
+   container keys are considered
+ - `curtailment::Bool = true`: include curtailment columns when parameters allow
+ - `storage::Bool = true`: include storage injection variables
+ - `sources::Bool = true`: include source injection variables and parameters
+
+# Returns
+ - [`PowerData`](@ref) with generation-related tables and aligned timestamps
+
+See also [`get_load_data`](@ref), [`get_service_data`](@ref), [`categorize_data`](@ref).
+"""
 function get_generation_data(
     results::R;
     # aggregation::Union{
@@ -452,6 +494,25 @@ function get_generation_data(
     return PowerData(variables, timestamps)
 end
 
+"""
+Extract load time series from simulation `results` into a [`PowerData`](@ref).
+
+# Arguments
+ - `results`: an [`InfrastructureSystems.Results`](@extref) object
+
+# Keyword Arguments
+ - `filter_func::Union{Function, Nothing} = nothing`: component filter for columns
+ - `initial_time` / `start_time`: start of the realized window
+ - `horizon` / `len`: number of time steps to read
+ - `variable_keys`, `parameter_keys`, `aux_variable_keys`: override optimization
+   container keys considered for load
+
+# Returns
+ - [`PowerData`](@ref) with load tables and aligned timestamps
+
+See also [`get_load_data`](@ref) for a [`PowerSystems.System`](@extref),
+[`get_generation_data`](@ref).
+"""
 function get_load_data(
     results::R;
     filter_func::Union{Function, Nothing} = nothing,
@@ -522,6 +583,28 @@ end
 get_base_power(system::PSY.System) = PSY.get_base_power(system)
 get_base_power(results::IS.Results) = IS.get_base_power(results)
 
+"""
+Build load forecast [`PowerData`](@ref) from a [`PowerSystems.System`](@extref)
+(no simulation results required).
+
+Uses deterministic `max_active_power` time series on static loads, grouped by
+`aggregation`.
+
+# Arguments
+ - `system`: system containing load components and forecasts
+
+# Keyword Arguments
+ - `aggregation`: grouping type — `StaticLoad` (default), `ACBus`, `System`, or an
+   `AggregationTopology` subtype (e.g. `Area`)
+ - `horizon`: forecast horizon (period or step count; default: system forecast horizon)
+ - `initial_time`: forecast window start (default: system forecast initial timestamp)
+
+# Returns
+ - [`PowerData`](@ref) whose `data` keys are aggregation names and whose values are
+   load forecast tables
+
+See also [`get_load_data`](@ref) for [`InfrastructureSystems.Results`](@extref).
+"""
 function get_load_data(
     system::PSY.System;
     aggregation::Union{
@@ -586,6 +669,23 @@ function get_load_data(
     return PowerData(parameters, time_range)
 end
 
+"""
+Extract ancillary-service variable time series from `results` into a [`PowerData`](@ref).
+
+# Arguments
+ - `results`: an [`InfrastructureSystems.Results`](@extref) object
+
+# Keyword Arguments
+ - `filter_func::Union{Function, Nothing} = nothing`: component filter for columns
+ - `initial_time` / `start_time`: start of the realized window
+ - `horizon` / `len`: number of time steps to read
+ - `variable_keys`: override which service variable keys are read
+
+# Returns
+ - [`PowerData`](@ref) with service tables and aligned timestamps
+
+See also [`get_generation_data`](@ref), [`get_load_data`](@ref).
+"""
 function get_service_data(
     results::R;
     filter_func::Union{Function, Nothing} = nothing,
@@ -615,14 +715,23 @@ end
 #### result combination and aggregation ####
 
 """
-aggregates and combines data into single DataFrame
+Aggregate each category DataFrame in `data` to a single column and horizontally
+combine them into one DataFrame.
+
+# Arguments
+ - `data`: dictionary of category name => wide DataFrame (as in [`PowerData`](@ref).data)
+
+# Keyword Arguments
+ - `names`: category order (default: `keys(data)`)
+ - `aggregate`: row-wise aggregator applied to each matrix (default: sum over columns)
 
 # Example
 
 ```julia
-PG.combine_categories(gen_uc.data)
+combine_categories(gen_uc.data)
 ```
 
+See also [`categorize_data`](@ref).
 """
 function combine_categories(
     data::Union{Dict{Symbol, DataFrames.DataFrame}, Dict{String, DataFrames.DataFrame}};
@@ -646,16 +755,29 @@ function combine_categories(
 end
 
 """
-Re-categorizes data according to an aggregation dictionary
-* makes no guarantee of complete data collection *
+Re-group [`PowerData`](@ref) tables by an aggregation dictionary (e.g. fuel categories).
+
+Makes no guarantee of complete data collection for components missing from
+`aggregation`.
+
+# Arguments
+ - `data`: dictionary of variable-key symbol => wide DataFrame (typically
+   `get_generation_data(...).data`)
+ - `aggregation`: map from category name to generator `(type, name)` pairs, as from
+   [`make_fuel_dictionary`](@ref)
+
+# Keyword Arguments
+ - `curtailment::Bool = true`: include curtailment columns when present
+ - `slacks::Bool = true`: include slack variables when present
 
 # Example
 
 ```julia
-aggregation = PA.make_fuel_dictionary(results_uc.system)
-categorize_data(gen_uc.data, aggregation)
+aggregation = make_fuel_dictionary(sys)
+categorize_data(gen.data, aggregation)
 ```
 
+See also [`combine_categories`](@ref), [`make_fuel_dictionary`](@ref).
 """
 function categorize_data(
     data::Dict{Symbol, DataFrames.DataFrame},

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -163,9 +163,13 @@ struct NoResultError <: Exception
 end
 
 # Override these if you define Metric subtypes with different implementations
+"""Return the name string of metric `m`."""
 get_name(m::Metric) = m.name
+"""Return the evaluation function of metric `m`."""
 get_eval_fn(m::Metric) = m.eval_fn
+"""Return the time aggregation function of timed metric `m`."""
 get_time_agg_fn(m::TimedMetric) = m.time_agg_fn
+"""Return the component aggregation function of component-timed metric `m`."""
 get_component_agg_fn(m::ComponentTimedMetric) = m.component_agg_fn
 get_time_meta_agg_fn(m::TimedMetric) = m.time_meta_agg_fn
 get_component_meta_agg_fn(m::ComponentTimedMetric) = m.component_meta_agg_fn


### PR DESCRIPTION
**New export**: `combine_categories`, part of the old PA workflow used by PowerGraphics. Not currently hyperlinking it from PG, and assuming it's about to be deleted anyways as part of PG rework. But if that doesn't happen, it'll be available to link

**Major documentation improvements:**

*New guides and explanations:*
- Added new "How to..." guides on grouping generation by fuel/technology (`how_to_group_generation_by_fuel.md`) and defining custom metrics (`how_to_define_a_custom_metric.md`), providing step-by-step instructions and code examples. [[1]](diffhunk://#diff-23093dcef77977de81d3caa5f315cb4515bd80bed9498f99c0433cb49c148d93R1-R61) [[2]](diffhunk://#diff-0ba4f8199db900d934c395b2edfc2f0ffb084f681e13865c2e75ab1b72711028R1-R82)
- Introduced in-depth explanation pages: "How PowerAnalytics thinks" (metrics and selectors mental model) and "Choosing built-in metrics" (comparison and caveats for built-ins). [[1]](diffhunk://#diff-a82c78792d65b991fc555a273db3bb77efbba85e2ab96c685aebb74aba00bfb2R1-R68) [[2]](diffhunk://#diff-e4740fc692c7d017367903b87835647a5c796a1ac11e6d6a23beeca19fc75ae2R1-R58)

*Navigation and structure:*
- Updated the documentation navigation (`make.jl`) to include the new "How to..." and "Explanation" sections, replacing previous TODOs.
- Removed obsolete stub pages for how-to and explanation sections. [[1]](diffhunk://#diff-0c7a3a9ecfc84d92eee77abd7f7d77be3905b2b758fbb472f3d70bbb99a5d148L1-L3) [[2]](diffhunk://#diff-2b3903098cde49bd853178cade04e314715c11a95776d7810fcf36d92f9219b6L1-L3)

**General documentation cleanup and enhancements:**

*Improved references and cross-linking:*
- Updated cross-references to use `@ref` and `@extref` for easier navigation, including in the main index, developer guidelines, and tutorial. [[1]](diffhunk://#diff-36c852523b6a7513a10b8a6bae21f1037eaa27484efc9042f75bbda46d9f529bL5-R8) [[2]](diffhunk://#diff-36c852523b6a7513a10b8a6bae21f1037eaa27484efc9042f75bbda46d9f529bL19-R23) [[3]](diffhunk://#diff-34ec429f372c83ee62bb434bc8026638aa48509a770913070ebedc45b2b1f533L7-R8) [[4]](diffhunk://#diff-1d06aa2660333de5d07bdf1681afff4712711439a6c1aa92afc75b2155ff4504L46-R46) [[5]](diffhunk://#diff-1d06aa2660333de5d07bdf1681afff4712711439a6c1aa92afc75b2155ff4504L91-R91) [[6]](diffhunk://#diff-257177ed9df24ad90102878e3973bcb6395b8f5b84fd6cf28ce255d0e181bf56L5-R6)
- Clarified language around the use of `ComponentSelector` and its documentation. [[1]](diffhunk://#diff-257177ed9df24ad90102878e3973bcb6395b8f5b84fd6cf28ce255d0e181bf56L5-R6) [[2]](diffhunk://#diff-36c852523b6a7513a10b8a6bae21f1037eaa27484efc9042f75bbda46d9f529bL5-R8)

*Minor content and formatting fixes:*
- Fixed line breaks, clarified version support, and corrected minor typos in the index and Sienna ecosystem overview. [[1]](diffhunk://#diff-36c852523b6a7513a10b8a6bae21f1037eaa27484efc9042f75bbda46d9f529bL35-R35) [[2]](diffhunk://#diff-36c852523b6a7513a10b8a6bae21f1037eaa27484efc9042f75bbda46d9f529bL19-R23)